### PR TITLE
Add more ecommerce integration coverage

### DIFF
--- a/tests/ecommerce-flow.spec.ts
+++ b/tests/ecommerce-flow.spec.ts
@@ -34,6 +34,34 @@ test('customer can add and remove a product from the cart', async ({ page }) => 
   await expect(productRow).toBeHidden()
 })
 
+test('customer can update cart item quantity', async ({ page }) => {
+  await addProductToCart(page)
+  await page.goto('/kurv', { waitUntil: 'domcontentloaded' })
+
+  const productRow = page.locator('li').filter({ hasText: productName }).first()
+  const quantityInput = productRow.locator('input[name="quantity"]')
+  await expect(quantityInput).toHaveValue('1')
+
+  await quantityInput.fill('2')
+  await quantityInput.dispatchEvent('change')
+  await expect(quantityInput).toHaveValue('2')
+
+  await quantityInput.fill('1')
+  await quantityInput.dispatchEvent('change')
+  await expect(quantityInput).toHaveValue('1')
+})
+
+test('checkout form marks invalid postal codes as invalid', async ({ page }) => {
+  await addProductToCart(page)
+  await page.goto('/kurv', { waitUntil: 'domcontentloaded' })
+
+  const postalCodeInput = page.getByRole('textbox', { name: 'Postnummer' })
+  await postalCodeInput.fill('abcd')
+
+  await expect(postalCodeInput).toHaveAttribute('pattern', '\\d*')
+  await expect(postalCodeInput).toHaveJSProperty('validity.valid', false)
+})
+
 test('customer can continue from cart to payment', async ({ page }) => {
   await addProductToCart(page)
   await page.goto('/kurv', { waitUntil: 'domcontentloaded' })

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test'
+
+test('mobile menu opens, navigates, and closes after navigation', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+  const menuButton = page.getByRole('button', { name: 'Navigations menu' })
+  await expect(menuButton).toBeVisible()
+
+  await menuButton.click()
+  await expect(page.getByRole('link', { name: 'Sortiment' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Smagninger' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Inspiration' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Forhandlere' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Om Os' })).toBeVisible()
+
+  await page.getByRole('link', { name: 'Sortiment' }).click()
+  await expect(page).toHaveURL(/\/sortiment$/)
+  await expect(page.getByRole('link', { name: 'Sortiment' })).toBeHidden()
+})

--- a/tests/payment.spec.ts
+++ b/tests/payment.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+test('payment success page redirects to payment error without a cart', async ({ page }) => {
+  await page.goto('/betaling/success', { waitUntil: 'domcontentloaded' })
+
+  await expect(page).toHaveURL(/\/betaling\/fejl$/)
+  await expect(page.getByText('Vi kunne ikke gennemføre betalingen.')).toBeVisible()
+})
+
+test('payment error page links customers back to payment', async ({ page }) => {
+  await page.goto('/betaling/fejl', { waitUntil: 'domcontentloaded' })
+
+  await expect(page.getByRole('heading', { name: 'Hovsa!' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Prøv igen' })).toHaveAttribute('href', '/betaling')
+})


### PR DESCRIPTION
## Summary
- add Playwright coverage for cart quantity edits and checkout postal-code validity
- add mobile navigation coverage for opening, navigating, and closing the menu
- add payment result page coverage for success-without-cart redirect and retry link

## Verification
- pnpm run check
- pnpm exec prettier --check tests/ecommerce-flow.spec.ts tests/navigation.spec.ts tests/payment.spec.ts
- pnpm exec eslint --max-warnings=0 tests/ecommerce-flow.spec.ts tests/navigation.spec.ts tests/payment.spec.ts
- pnpm test:integration