### PR TITLE
[codex] Add payment info analytics event

### DIFF
--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -216,6 +216,33 @@ export function trackAddShippingInfo({
   })
 }
 
+export function trackAddPaymentInfo({
+  currency,
+  paymentType,
+  items,
+}: {
+  currency?: string
+  paymentType: string
+  items: GaListItem[]
+}) {
+  withDataLayer((dataLayer) => {
+    const payload = {
+      event: 'add_payment_info',
+      ecommerce: {
+        ...(currency ? { currency } : {}),
+        payment_type: paymentType,
+        items,
+      },
+    }
+
+    if (import.meta.env.DEV) {
+      console.info('[analytics] add_payment_info payload', payload)
+    }
+
+    dataLayer.push(payload)
+  })
+}
+
 export function trackPurchase({
   address,
   currency,

--- a/src/routes/orders/[id]/+page.svelte
+++ b/src/routes/orders/[id]/+page.svelte
@@ -4,6 +4,7 @@
   import {
     GA_CATEGORY_LABEL_BY_HANDLE,
     GA_MISSING,
+    trackAddPaymentInfo,
     trackPurchase,
     type GaListItem,
     type GaPurchaseAddress,
@@ -13,6 +14,21 @@
 
   const { data }: { data: PageData } = $props()
   const { locale, order } = $derived(data)
+
+  type AddPaymentInfoMetadata = {
+    paymentMethodType?: string
+    paymentMethodSubType?: string
+  }
+
+  type PaymentCollectionWithMetadata = {
+    metadata?: {
+      add_payment_info?: AddPaymentInfoMetadata
+    } | null
+  }
+
+  type OrderWithPaymentCollections = {
+    payment_collections?: PaymentCollectionWithMetadata[] | PaymentCollectionWithMetadata
+  }
 
   function getCategoryHandle(color: string): keyof typeof GA_CATEGORY_LABEL_BY_HANDLE {
     if (color === 'RED') return 'red'
@@ -55,6 +71,24 @@
     return shippingCode ?? ''
   }
 
+  function getPaymentType() {
+    const { payment_collections: paymentCollections } =
+      order as unknown as OrderWithPaymentCollections
+    const collections = Array.isArray(paymentCollections)
+      ? paymentCollections
+      : paymentCollections
+        ? [paymentCollections]
+        : []
+    const addPaymentInfo = collections
+      .map((collection) => collection.metadata?.add_payment_info)
+      .find((metadata): metadata is AddPaymentInfoMetadata => !!metadata?.paymentMethodType)
+
+    if (!addPaymentInfo) return ''
+    if (!addPaymentInfo.paymentMethodSubType) return addPaymentInfo.paymentMethodType
+
+    return `${addPaymentInfo.paymentMethodType}-${addPaymentInfo.paymentMethodSubType}`
+  }
+
   function getTransactionId() {
     const captureTransaction = (order.transactions ?? []).find(
       (transaction) => transaction.reference === 'capture',
@@ -80,11 +114,22 @@
   }
 
   onMount(() => {
+    const paymentType = getPaymentType()
+    const items = toGaItems()
+
+    if (paymentType) {
+      trackAddPaymentInfo({
+        currency: order.currency_code.toUpperCase(),
+        paymentType,
+        items,
+      })
+    }
+
     trackPurchase({
       address: getPurchaseAddress(),
       currency: order.currency_code.toUpperCase(),
       coupon: getCouponCode(),
-      items: toGaItems(),
+      items,
       shipping: String(order.shipping_total),
       tax: String(order.tax_total),
       transactionId: getTransactionId(),


### PR DESCRIPTION
## Summary

- add a `trackAddPaymentInfo` dataLayer helper for GA ecommerce
- emit `add_payment_info` on the order confirmation page before purchase
- derive `payment_type` from payment collection metadata as `paymentMethodType-paymentMethodSubType` when subtype is available

## Validation

- `git diff --check`
- `PUBLIC_MEDUSA_PUBLISHABLE_KEY=test PUBLIC_VITE_BACKEND_URL=http://localhost:9000 EPAY_API_KEY=test PUBLIC_COOKIE_YES_ID=test PUBLIC_GA_MEASUREMENT_ID=test npm run check` passed with existing warnings

Note: the regular pre-commit hook runs `npm run check` without local env vars and fails in this worktree because required SvelteKit static env exports are missing.
