### PR TITLE
VNU-9 Show selected shipping price in cart

### DIFF
--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -30,6 +30,17 @@
   let selectedShippingMethodId = $derived(
     cart.shipping_methods?.[0]?.shipping_option_id ?? shippingOptions[0]?.id ?? '',
   )
+  const hasCartShippingMethod = $derived(Boolean(cart.shipping_methods?.length))
+  const selectedShippingOption = $derived(
+    shippingOptions.find(({ id }) => id === selectedShippingMethodId),
+  )
+  const selectedShippingPrice = $derived(getShippingOptionPrice(selectedShippingOption))
+  const displayedShippingTotal = $derived(
+    hasCartShippingMethod ? cart.shipping_total : selectedShippingPrice,
+  )
+  const displayedCartTotal = $derived(
+    hasCartShippingMethod ? cart.total : cart.total + (displayedShippingTotal ?? 0),
+  )
   let isSubmitting = $state(false)
   let hasCheckoutRedirected = $state(false)
   const checkoutState = $derived<'idle' | 'processing' | 'redirecting'>(
@@ -63,9 +74,15 @@
     isSubmitting = false
   }
 
-  function formattedPrice(price: number) {
+  function formattedPrice(price: number | undefined) {
+    if (price === undefined) return ''
     if (price === 0) return 'Gratis'
     return formatPrice(price, region.currency_code, locale)
+  }
+
+  function getShippingOptionPrice(option?: { amount?: number | null; id: string }) {
+    if (!option) return undefined
+    return shippingPrices[option.id] ?? option.amount ?? undefined
   }
 
   async function calculateShippingPrices() {
@@ -280,11 +297,11 @@
         </div>
         <div class="flex justify-between">
           <dt>Levering</dt>
-          <dd>{formattedPrice(cart?.shipping_total)}</dd>
+          <dd>{formattedPrice(displayedShippingTotal)}</dd>
         </div>
         <div class="flex justify-between">
           <dt>I alt</dt>
-          <dd>{formattedPrice(cart?.total)}</dd>
+          <dd>{formattedPrice(displayedCartTotal)}</dd>
         </div>
       </dl>
       <p class="text-xs mb-2">Inklusiv {formattedPrice(cart?.tax_total)} i afgifter</p>
@@ -431,7 +448,7 @@
           options={shippingOptions.map((option) => ({
             description: option.type.description,
             label: option.name,
-            price: formattedPrice(shippingPrices[option.id]),
+            price: formattedPrice(getShippingOptionPrice(option)),
             value: option.id,
           }))}
           bind:selected={selectedShippingMethodId}

--- a/tests/ecommerce-flow.spec.ts
+++ b/tests/ecommerce-flow.spec.ts
@@ -30,6 +30,22 @@ test('customer can add and remove a product from the cart', async ({ page }) => 
   await expect(productRow).toBeVisible()
   await expect(productRow.locator('input[name="quantity"]')).toHaveValue('1')
 
+  const selectedShippingMethod = page
+    .locator('fieldset')
+    .filter({ hasText: 'Leveringsmetode' })
+    .locator('label')
+    .filter({ has: page.locator('input:checked') })
+  const selectedShippingPrice = await selectedShippingMethod.locator('p').nth(1).innerText()
+  const deliverySummaryPrice = page
+    .locator('dl')
+    .filter({ hasText: 'Subtotal' })
+    .first()
+    .locator('div')
+    .filter({ hasText: 'Levering' })
+    .locator('dd')
+
+  await expect(deliverySummaryPrice).toHaveText(selectedShippingPrice)
+
   await productRow.getByRole('button', { name: `Fjern ${productName} fra kurv.` }).click()
   await expect(productRow).toBeHidden()
 })


### PR DESCRIPTION
## Summary
- Show the selected delivery method price in the cart summary before the shipping method is added to the cart
- Include that display-only shipping price in the visible order total
- Add an integration assertion for the selected shipping price in the cart summary

## Verification
- pnpm check
- pnpm exec prettier --check tests/ecommerce-flow.spec.ts src/routes/kurv/+page.svelte
- pnpm exec eslint tests/ecommerce-flow.spec.ts src/routes/kurv/+page.svelte
- git diff --check
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5173 pnpm exec playwright test tests/ecommerce-flow.spec.ts --grep "customer can add and remove a product from the cart"