### PR TITLE
[codex] VNU-11 update agent command guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ This is a SvelteKit e-commerce project for a vermouth store using:
 
 ## Commands
 
+Prefer the scripts defined in `package.json` for standard project workflows.
+Use direct `pnpm exec ...` commands only when there is no matching script or when
+running a focused command against specific files.
+
 ### Branch And Issue Workflow
 
 - Follow the global Codex branch isolation rules: one Linear issue, one branch.
@@ -66,17 +70,6 @@ EPAY_API_KEY=test \
 PUBLIC_COOKIE_YES_ID= \
 PUBLIC_GA_MEASUREMENT_ID= \
 pnpm check
-```
-
-- When starting a local dev server for browser checks, bind to localhost explicitly if host mode is blocked:
-
-```bash
-PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test \
-PUBLIC_VITE_BACKEND_URL=http://127.0.0.1:9000 \
-EPAY_API_KEY=test \
-PUBLIC_COOKIE_YES_ID= \
-PUBLIC_GA_MEASUREMENT_ID= \
-pnpm exec vite dev --host 127.0.0.1 --port 5175
 ```
 
 - If `/kurv` renders a Vite 500 with `ERR_UNSUPPORTED_DIR_IMPORT` from `@medusajs/js-sdk/dist/esm/admin`, run `pnpm fix` and restart the dev server before browser verification.


### PR DESCRIPTION
## What changed
- Removed the project AGENTS.md instruction that hard-coded local browser checks to port 5175.
- Added guidance to prefer scripts defined in package.json for standard workflows, using direct pnpm exec commands only for missing scripts or focused file-level commands.

## Why
VNU-11 asks to remove stale fixed-port guidance and make command selection less confusing for future agent runs.

Linear: https://linear.app/zwergius/issue/VNU-11/remove-fixed-port-5175-local-dev-guidance

## Acceptance criteria checked
- AGENTS.md no longer mentions port 5175 or the fixed vite dev command.
- Changes are isolated to AGENTS.md on the VNU-11 branch.
- No package metadata or unrelated project files changed.

## How to test
- git diff --check

## Risk
Low. Documentation-only change.

## Intentionally not done
- Did not change runtime code or package scripts.
- Did not modify VNU-10 route implementation work.

## Agent involvement
Implemented by Codex.