### PR TITLE
[codex] VNU-12 remove deprecated product fields

### DIFF
--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -9,27 +9,19 @@ export type Handle =
   | 'tabira'
 
 interface Vermouth {
-  color: 'RED' | 'WHITE' | 'ORANGE' // deprecated
-  country: string
   extraImages: Array<{ altText: string; url: string }>
   image: string
-  intro: string // deprecated
-  name: string // deprecated
   brand: string
   origin: string
   recommendation: string
-  region: string
   scores: { body: number; fruityness: number; spiciness: number; sweetness: number }
   sizeAndDegrees: string
   taste: string
-  titleName: string //deprecated
 }
 
 export const vermouths: Record<Handle, Vermouth> = {
   'forzudo-rojo': {
     brand: 'Forzudo',
-    color: 'RED',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Bartender forbereder en cocktail med Forzudo Rojo',
@@ -53,22 +45,15 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/d9b17e95-18c8-4ded-a15b-182fb859c800',
-    intro:
-      'Med sin mørke mahogni farve, præsenterer denne vermouth sig på klassisk vis, og dog med et tvist.',
-    name: 'Forzudo Rojo',
     origin: 'El Bierzo Leon, Nordvest Spanien 100 cl. / 15%',
     recommendation: 'Bør nydes afkølet og med en skive grape.',
-    region: 'Bierzo, Leon, Nordvest',
     scores: { sweetness: 1, fruityness: 2, body: 2, spiciness: 3 },
     sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Smagen er levende og koncentreret, hvor især kardemommen og de tørrede frugter er stærke, derudover er der nuancer af lakrids og vanilje. Duften er intens af søde krydderier blandet med tørret frugt som afsluttes med noter af kaffe. Dette gør sig gældende i en lang og vedvarende sødme med et perfekt bitter touch.',
-    titleName: 'Klassens frække dreng',
   },
   'forzudo-blanco': {
     brand: 'Forzudo',
-    color: 'WHITE',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Forzudo Blanco bliver taget fra en hylde',
@@ -92,21 +77,15 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/e5eb8eb6-444c-4217-6143-e652c2a9a100',
-    intro: 'Forzudo Blanco er yderste populær, og et perfekt følgeskab til en dag i solen.',
-    name: 'Forzudo Blanco',
     origin: 'El Bierzo Leon, Nordvest Spanien 100 cl. / 15%',
     recommendation: 'Bør nydes afkølet og med en skive grape.',
-    region: 'Bierzo, Leon, Nordvest',
     scores: { sweetness: 2, fruityness: 2, body: 2, spiciness: 2 },
     sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Forzudo Blanco giver en cremet fornemmelse med smagsnuancer af bittert æble, kandiseret citron, grønne urter og et strejf af tropiske frugter. Her fås en meget balanceret Vermouth med lige dele sødme og bitter.',
-    titleName: 'Forfriskende og stærkt vanedanende',
   },
   'sardino-rojo': {
     brand: 'Sardino',
-    color: 'RED',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'En hånd tager en flaske Sardino Rojo fra en hylde',
@@ -126,23 +105,16 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/89f026f1-f193-45b4-bf8a-a9f9d89c3e00',
-    intro:
-      'Sardino slår sig selv op på at være en maritim vermouth, den kommer helt fra den Spanske vestkyst, hvor der er store fiske traditioner og lækre råvarer.',
-    name: 'Sardino Rojo',
     origin: 'Galicien, Nordvestkysten Spanien 75 cl / 15%',
     recommendation:
       'Serveres “on the rocks”, med en skive appelsin eller citron, nydes som aperitif med en lille snack ved hånden f.eks oliven, chips eller “fisk på dåse”',
-    region: 'Galicien, Nordvestkysten',
     scores: { sweetness: 5, fruityness: 3, body: 5, spiciness: 4 },
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'En rigtig god allround rød Vermouth som hverken er for sød, tør eller bitter - perfekt til enhver lejlighed. Noter af karamel, camille & kanel.',
-    titleName: 'Sømandens foretrukne',
   },
   'sardino-blanco': {
     brand: 'Sardino',
-    color: 'WHITE',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Bakke med Sardino Blanco anretning',
@@ -154,23 +126,16 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/910a8496-b9ad-4685-f102-dea0a0e60d00',
-    intro:
-      'Sardino Blanco, lagret i lerkrukker ved Atlanterhavets kyst - Her i den hvide udgave som er en anelse lettere.',
-    name: 'Sardino Blanco',
     origin: 'Galicien, Nordvestkysten Spanien 75 cl / 15%',
     recommendation:
       'Serveres ved 6-8 grader i glas med oliven og en skive appelsin. Nydes til forretter eller som aperitif med en lille snack ved hånden f.eks oliven, chips eller “fisk på dåse”.',
-    region: 'Galicien, Nordvestkysten',
     scores: { sweetness: 5, fruityness: 3, body: 4, spiciness: 2 },
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Halmgul i farven, stor harmoni og balance i smag, sødt og syrligt med friske og frugtige nuancer, meget aromatisk og med en lang smagsudholdenhed. Noter af blomster, planter og botaniske stoffer.',
-    titleName: 'Maritim Vermouth fra den Spanske vestkyst',
   },
   'carmeleta-orange': {
     brand: 'Carmeleta',
-    color: 'ORANGE',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Carmeleta Orange Vermouth Tonic cocktails',
@@ -186,22 +151,15 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/682acd17-1447-46b6-af38-73a4e9864600',
-    intro:
-      'Carmeleta Vermouth Orange præsenterer en levende orange farve, en hyldest til Appelsinen fra Valencia. Brygget på hvide druer fra middelhavsområdet, herunder Malvasía, Moscatel, Planta, udviklet med en original kombination af urter og krydderrier. En klassisk blanding med bløde toner af Malurt, Artemis og Dictamo fra Kreta. Sødere og lettere end en traditionel vermouth, egner sig til alle tidspunkter af dagen. En ny vermouth til nye tider.',
-    name: 'Carmeleta Orange',
     origin: 'L’Alquería de la Comtessa Valencia 75cl / 15%',
     recommendation: 'Serveres kold med is, og evt. et jordbær eller appelsin.',
-    region: 'L’Alquería de la Comtessa, Valencia',
     scores: { sweetness: 4, fruityness: 4, body: 5, spiciness: 1 },
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Noter af citrusfrugter, kager, vanille karamel. Intens smag, afbalanceret med syrlighed. Let bitter citrus og krydret eftersmag. Carmeleta Orange har en frisk duft, balanceret med syrlighed samt søde og bitre undertoner.',
-    titleName: 'Orange og Trendy',
   },
   'carmeleta-blanco': {
     brand: 'Carmeleta',
-    color: 'WHITE',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Carmeleta Blanco cocktail',
@@ -213,23 +171,16 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/684162e5-028c-4ccd-0057-4f9c9a0f4900',
-    intro:
-      'Carmeleta Blanco er en autentisk vermouth som kombinerer aromatiske urter og krydderier, hvilket gør den hvide vermouth til en forfriskende aperitif. Lavet på hvide druer fra middelhavsområdet, herunder Malvasía, Muscat, Planta og udviklet med en original kombination af urter og krydderrier. En klassisk blanding med bløde toner af Malurt, Artemis og Dictamo fra Kreta. Vermouthen er sødere og lettere end en traditionel rød vermouth, og egner sig til alle tidspunkter af dagen. En sand Gane Gentleman.',
-    name: 'Carmeleta Blanco',
     origin: 'L’Alquería de la Comtessa Valencia 75cl / 15%',
     recommendation:
       'Serveres kold med is, alternativt i drinks med gin som en forfriskende supplement.',
-    region: 'L’Alquería de la Comtessa, Valencia',
     scores: { sweetness: 2, fruityness: 3, body: 2, spiciness: 3 },
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Smagen er karakteriseret af elegante smage fra de traditionelle smage fra vermouth, men forfriskede med behagelige noter fra Ingefær og Saigon Kanel og afslutningsvis er vermouthen tilsmagt med fennikel og timian. Næsen er forfriskende og har klare noter af timian og fennikel.',
-    titleName: 'Hvid og Autentisk',
   },
   'carmeleta-rosso': {
     brand: 'Carmeleta',
-    color: 'RED',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Negroni cocktail lavet med Forzudo Rojo',
@@ -241,23 +192,16 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/95ec3491-7126-4e90-a732-a8cf64eb5000',
-    intro:
-      'Carmeleta Rosso, født af Valencias varme jord, bittersøde citrusfrugter og den mediterrane passion for aperitivo. En intens og karakterfuld vermouth, hvor noter af lakrids, appelsinskal og varme krydderier møder friske urter og florale nuancer. Malvasia, moscatel og planta nova danner fundamentet, mens malurt, artemisia og saigonkanel tilfører dybde, bitterhed og elegance.',
-    name: 'Carmeleta Rosso',
     origin: 'L’Alquería de la Comtessa Valencia 75cl / 15%',
     recommendation:
       'Serveres bedst over is med appelsinskal – eller som fundament i klassiske cocktails som Negroni og Manhattan.',
-    region: 'L’Alquería de la Comtessa, Valencia',
     scores: { sweetness: 3, fruityness: 2, body: 3, spiciness: 5 },
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'I næsen opleves Rosso aromatisk og balsamisk med mørke citrusnoter og krydret sødme. Smagen er fyldig og harmonisk med en flot balance mellem syre, bitterhed og sødme. Den lange finish efterlader noter af appelsin, krydderier og et elegant bittert bid.',
-    titleName: 'Essensen fra appelsintræet',
   },
   tabira: {
     brand: 'Tabira',
-    color: 'RED',
-    country: 'Spanien',
     extraImages: [
       {
         altText: 'Bakke anretning med Tabira Vermouth på en bakke i en båd',
@@ -269,16 +213,11 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/214da185-c1c9-4a72-f012-62d5bf8f0600',
-    intro:
-      'Vinhuset Meoriga, fra byen Leon præsenterer den første vermouth lavet på druen “Prieto Picudo”. En premium vermouth med begrænset årlig produktion, baseret på en original opskrift som er mere end 90 år gammel (1927).',
-    name: 'Tabira',
     origin: 'Leon Nordvest Spanien 100 cl. / 15%',
     recommendation: 'Kold, med is og oliven som aperitif. Eller til en cocktail med rom, whisky',
-    region: 'Leon, Nordvest',
     scores: { sweetness: 3, fruityness: 2, body: 4, spiciness: 4 },
     sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Sødlig og blød i sin smag, dens friskhed og duft af appelsin gør den nem at drikke. Eftersmagen ligger langt tilbage i munden og arbejder sig ind, igennem sine mange aromaer og krydderier. Perfekt balance mellem det søde og det friske, som gør denne vermouth meget komplet. Bør nydes kold med is og appelsinskive, og med oliven som snack.',
-    titleName: 'Elegant Vermouth med dragende næse og smag',
   },
 } as const

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -54,6 +54,7 @@
     previousQuantity: number
     productId?: string
   }
+  type CategoryHandle = keyof typeof GA_CATEGORY_LABEL_BY_HANDLE
 
   function handleCheckoutResult(result: ActionResult) {
     if (result.type === 'redirect') {
@@ -87,16 +88,22 @@
     form?.requestSubmit()
   }
 
-  function getCategoryHandle(color: string): keyof typeof GA_CATEGORY_LABEL_BY_HANDLE {
-    if (color === 'RED') return 'red'
-    if (color === 'WHITE') return 'white'
-    return 'other'
+  function getCategoryHandleByProductHandle(productHandle?: string): CategoryHandle | null {
+    if (!productHandle) return null
+
+    for (const categoryHandle of ['red', 'white', 'other'] as const) {
+      if (data.categories[categoryHandle].some((product) => product.handle === productHandle)) {
+        return categoryHandle
+      }
+    }
+
+    return null
   }
 
   function toGaItem(context: CartItemAnalyticsContext, quantity: string): GaListItem {
     const handle = context.productHandle
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
-    const categoryHandle = staticData ? getCategoryHandle(staticData.color) : null
+    const categoryHandle = getCategoryHandleByProductHandle(handle)
 
     return {
       item_id: context.productId || context.cartItemId || GA_MISSING.itemId,

--- a/src/routes/orders/[id]/+page.svelte
+++ b/src/routes/orders/[id]/+page.svelte
@@ -14,6 +14,7 @@
 
   const { data }: { data: PageData } = $props()
   const { locale, order } = $derived(data)
+  type CategoryHandle = keyof typeof GA_CATEGORY_LABEL_BY_HANDLE
 
   type AddPaymentInfoMetadata = {
     paymentMethodType?: string
@@ -30,17 +31,23 @@
     payment_collections?: PaymentCollectionWithMetadata[] | PaymentCollectionWithMetadata
   }
 
-  function getCategoryHandle(color: string): keyof typeof GA_CATEGORY_LABEL_BY_HANDLE {
-    if (color === 'RED') return 'red'
-    if (color === 'WHITE') return 'white'
-    return 'other'
+  function getCategoryHandleByProductHandle(productHandle?: string | null): CategoryHandle | null {
+    if (!productHandle) return null
+
+    for (const categoryHandle of ['red', 'white', 'other'] as const) {
+      if (data.categories[categoryHandle].some((product) => product.handle === productHandle)) {
+        return categoryHandle
+      }
+    }
+
+    return null
   }
 
   function toGaItems() {
     return order.items!.map((item): GaListItem => {
       const handle = item.product_handle as Handle | null
       const staticData = handle && handle in vermouths ? vermouths[handle] : null
-      const categoryHandle = staticData ? getCategoryHandle(staticData.color) : null
+      const categoryHandle = getCategoryHandleByProductHandle(handle)
 
       return {
         item_id: item.product_id || item.id || GA_MISSING.itemId,

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -24,9 +24,10 @@
   const { data }: PageProps = $props()
   const { red, white, other } = $derived(data.categories)
   const { cart, locale, product, region } = $derived(data)
-  const { extraImages, image, intro, origin, recommendation, scores, taste } = $derived(
+  const { extraImages, image, origin, recommendation, scores, taste } = $derived(
     vermouths[product.handle as Handle],
   )
+  const productDescription = $derived(product.description ?? '')
   const variant = $derived(product.variants?.[0])
   const formattedPrice = $derived(
     formatPrice(variant?.calculated_price?.calculated_amount ?? 0, region.currency_code, locale),
@@ -51,17 +52,21 @@
     return 'bg-brand-blue'
   })
 
-  function getCategoryHandle(color: string): keyof typeof GA_CATEGORY_LABEL_BY_HANDLE {
-    if (color === 'RED') return 'red'
-    if (color === 'WHITE') return 'white'
-    return 'other'
+  function getCategoryHandle(): keyof typeof GA_CATEGORY_LABEL_BY_HANDLE | null {
+    for (const category of product.categories ?? []) {
+      if (category.handle === 'red' || category.handle === 'white' || category.handle === 'other') {
+        return category.handle
+      }
+    }
+
+    return null
   }
 
   function toGaItem(quantity: string): GaListItem {
     const handle = typeof product.handle === 'string' ? product.handle : null
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
     const price = product.variants?.[0]?.calculated_price?.calculated_amount
-    const categoryHandle = staticData ? getCategoryHandle(staticData.color) : null
+    const categoryHandle = getCategoryHandle()
 
     return {
       item_id: product.id || GA_MISSING.itemId,
@@ -129,7 +134,7 @@
 
 <Seo
   title={product.title}
-  description={intro}
+  description={productDescription}
   image="{image}/w=800,h=800,fit=cover"
   imageAlt={product.title}
 />
@@ -171,7 +176,7 @@
       href="/forhandlere">KØB ELLER SMAG HER &#8594;</a
     >
     <h3 class="text-sm font-bold mb-4">{product.subtitle}</h3>
-    <p class="text-sm mb-6">{intro}</p>
+    <p class="text-sm mb-6">{productDescription}</p>
     <h3 class="text-sm font-bold mb-4">Smag & Duft</h3>
     <p class="text-sm mb-6">{taste}</p>
     <h3 class="text-sm font-bold mb-4">Anbefaling</h3>

--- a/src/routes/sortiment/[slug=vermouth]/+page.ts
+++ b/src/routes/sortiment/[slug=vermouth]/+page.ts
@@ -12,21 +12,13 @@ export const load: PageLoad = async ({ params, parent }) => {
   const { region } = await parent()
   const data = await sdk.store.product.list({
     handle: params.slug,
-    fields: '*variants.calculated_price',
+    fields: '*categories,*variants.calculated_price',
     region_id: region.id,
   })
 
   const vermouth = vermouths[vermouthSlug]
-  const redVermouths = Object.values(vermouths).filter(({ color }) => color === 'RED')
-  const whiteVermouths = Object.values(vermouths).filter(({ color }) => color === 'WHITE')
-  const otherVermouths = Object.values(vermouths).filter(
-    ({ color }) => color !== 'WHITE' && color !== 'RED',
-  )
   return {
     product: data.products[0],
     vermouth,
-    redVermouths,
-    whiteVermouths,
-    otherVermouths,
   }
 }

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -28,11 +28,13 @@ test.describe('site pages', () => {
 
 test.describe('product detail pages', () => {
   for (const [handle, vermouth] of Object.entries(vermouths)) {
-    test(`/sortiment/${handle} renders ${vermouth.name}`, async ({ page }) => {
+    test(`/sortiment/${handle} renders product details`, async ({ page }) => {
       await page.goto(`/sortiment/${handle}`, { waitUntil: 'domcontentloaded' })
 
-      await expect(page.locator('h1')).toHaveText(vermouth.name)
-      await expect(page.getByRole('img', { name: vermouth.name }).first()).toBeVisible()
+      const productName = await page.locator('h1').innerText()
+
+      await expect(page.locator('h1')).not.toBeEmpty()
+      await expect(page.getByRole('img', { name: productName }).first()).toBeVisible()
       await expect(page.locator('main')).toContainText(vermouth.recommendation)
       await expect(page.getByRole('button', { name: 'LÆG I KURV' })).toBeVisible()
     })


### PR DESCRIPTION
## Summary

- Remove deprecated static product fields that now live in Medusa: name, intro, color, country, region, and titleName.
- Keep static product data focused on local presentation fields such as images, tasting notes, scores, origin text, brand, and recommendations.
- Update product detail, cart, and order analytics to use Medusa product/category data instead of removed static fields.
- Keep product detail integration coverage data-driven across every static product handle.

## Verification

- pnpm exec prettier --check src/lib/data/products.ts src/routes/kurv/+page.svelte src/routes/orders/[id]/+page.svelte src/routes/sortiment/[slug=vermouth]/+page.svelte src/routes/sortiment/[slug=vermouth]/+page.ts tests/pages.spec.ts
- pnpm exec eslint src/lib/data/products.ts src/routes/kurv/+page.svelte src/routes/orders/[id]/+page.svelte src/routes/sortiment/[slug=vermouth]/+page.svelte src/routes/sortiment/[slug=vermouth]/+page.ts tests/pages.spec.ts
- pnpm check
- pnpm test:integration (22 passed)