### PR TITLE
Prioritize parcel shop shipping options

### DIFF
--- a/src/routes/kurv/+page.ts
+++ b/src/routes/kurv/+page.ts
@@ -1,21 +1,37 @@
 import type { PageLoad } from './$types'
 import { sdk } from '$lib/medusa'
 
+const shippingTypeOrder: Record<string, number> = {
+  parcel_shop: 1,
+}
+
+function sortParcelShopShippingOptionsFirst<T extends { type: { code: string } }>(
+  shippingOptions: T[],
+) {
+  return [...shippingOptions].sort((first, second) => {
+    const firstType = first.type.code
+    const secondType = second.type.code
+
+    return (shippingTypeOrder[firstType] ?? 999) - (shippingTypeOrder[secondType] ?? 999)
+  })
+}
+
 export const load: PageLoad = async ({ parent }) => {
   const { cart } = await parent()
 
   const { shipping_options } = await sdk.store.fulfillment.listCartOptions({
     cart_id: cart.id,
   })
+  const shippingOptions = sortParcelShopShippingOptionsFirst(shipping_options)
 
   const shippingPrices = Object.fromEntries(
-    shipping_options
+    shippingOptions
       .filter(({ price_type }) => price_type === 'flat')
       .map(({ amount, id }) => [id, amount]),
   )
 
   const calculatedShippingPrices = await Promise.allSettled(
-    shipping_options
+    shippingOptions
       .filter(({ price_type }) => price_type !== 'flat')
       .map(({ id }) => sdk.store.fulfillment.calculate(id, { cart_id: cart.id, data: {} })),
   )
@@ -28,7 +44,7 @@ export const load: PageLoad = async ({ parent }) => {
   })
 
   return {
-    shippingOptions: shipping_options,
+    shippingOptions,
     shippingPrices,
   }
 }


### PR DESCRIPTION
## What changed
- Sort cart shipping options by Medusa shipping option type code.
- Prioritize options with `type.code === 'parcel_shop'` so DAO parcel shop appears first and is selected by default when no cart shipping method exists.
- Keep pricing, labels, and shipping submission behavior unchanged.

## Why
Linear: VNU-13

DAO collection/parcel shop should be the first shipping option in checkout.

## Acceptance criteria checked
- DAO parcel shop appears first in the `Leveringsmetode` options.
- Default/preselected option follows the sorted first option when the cart has no existing shipping method.
- Existing shipping prices and labels are not changed by this code.

## How to test
- `pnpm exec prettier --check src/routes/kurv/+page.ts`
- `pnpm exec eslint src/routes/kurv/+page.ts`
- `git diff --check`
- `PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test PUBLIC_VITE_BACKEND_URL=http://127.0.0.1:9000 EPAY_API_KEY=test PUBLIC_COOKIE_YES_ID= PUBLIC_GA_MEASUREMENT_ID= pnpm check`
- Browser verification via `pnpm dev`: `/kurv` showed `Dao - Pakkeshop` first and checked.

## Risk
Low. The change only reorders the shipping options array returned to the cart page. Unknown shipping type codes keep their relative fallback priority.

## Intentionally not done
- Did not change shipping option labels, prices, or Medusa configuration.
- Did not add a separate helper file; sorting stays local to the cart load.

## Agent involvement
Implemented by Codex.