### PR TITLE
[codex] VNU-18 rotate top banner messages

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,23 +1,53 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { page } from '$app/state'
+  import { dev } from '$app/environment'
   import { PUBLIC_COOKIE_YES_ID, PUBLIC_GA_MEASUREMENT_ID } from '$env/static/public'
   import '../app.css'
   import logo from '$lib/images/vermouth-nu-logo.svg'
+  import { reduced_motion } from '$lib/actions/reduced-motion'
   import { initializeAnalytics } from '$lib/helpers/analytics'
   import HamburgerMenu from '$lib/components/hamburger-menu.svelte'
   import type { LayoutProps } from './$types'
-  import { scale } from 'svelte/transition'
-  import { dev } from '$app/environment'
+  import { fade, scale } from 'svelte/transition'
 
   const routes = ['sortiment', 'smagninger', 'inspiration', 'forhandlere', 'om-os']
+  const topBannerMessages = [
+    {
+      href: '/sortiment',
+      text: 'Gratis fragt ved køb over 550 dkk',
+      variant: 'green',
+    },
+    {
+      href: '/smagninger',
+      text: 'Book en smagning',
+      variant: 'yellow',
+    },
+  ] as const
+
   const { children, data }: LayoutProps = $props()
   const { cart } = $derived(data)
+  let topBannerIndex = $state(0)
+  let isTopBannerPaused = $state(false)
+  const topBanner = $derived(topBannerMessages[topBannerIndex])
+  const topBannerFadeDuration = $derived($reduced_motion ? 0 : 400)
 
   onMount(() => {
     if (!PUBLIC_GA_MEASUREMENT_ID) return
 
     initializeAnalytics(PUBLIC_GA_MEASUREMENT_ID)
+  })
+
+  onMount(() => {
+    const interval = window.setInterval(() => {
+      if (isTopBannerPaused) return
+
+      topBannerIndex = (topBannerIndex + 1) % topBannerMessages.length
+    }, 5000)
+
+    return () => {
+      window.clearInterval(interval)
+    }
   })
 </script>
 
@@ -93,9 +123,23 @@
 {/snippet}
 
 <header class="sticky top-0 z-50 flex h-[--header-height] flex-col bg-brand-pink">
-  <a class="block bg-brand-yellow py-1.5 text-center text-xs" href="/smagninger"
-    >BOOK EN SMAGNING&nbsp;<span class="underline">NU</span></a
+  <a
+    class="grid overflow-hidden py-1.5 text-center text-xs"
+    class:bg-green-600={topBanner.variant === 'green'}
+    class:bg-brand-yellow={topBanner.variant === 'yellow'}
+    class:text-white={topBanner.variant === 'green'}
+    href={topBanner.href}
+    onblur={() => (isTopBannerPaused = false)}
+    onfocus={() => (isTopBannerPaused = true)}
+    onpointerenter={() => (isTopBannerPaused = true)}
+    onpointerleave={() => (isTopBannerPaused = false)}
   >
+    {#key topBannerIndex}
+      <span class="col-start-1 row-start-1" transition:fade={{ duration: topBannerFadeDuration }}>
+        {topBanner.text}&nbsp;<span class="underline">NU</span>
+      </span>
+    {/key}
+  </a>
   <nav class="flex-1 border-b border-t border-black text-sm">
     <ul class="nav-list h-full">
       <li class="col-span-2 lg:col-span-1">


### PR DESCRIPTION
## What changed
- Added a rotating top banner message for free shipping over 550 dkk.
- Shows the free-shipping message first, then fades to the existing tasting message every ~5 seconds.
- Uses green styling for the free-shipping message and keeps the tasting message yellow.
- Preserves banner links by pointing free shipping to /sortiment and tastings to /smagninger.
- Pauses rotation while the banner is hovered or focused and respects reduced motion.

## Why
- Supports VNU-18 by promoting free shipping while preserving the existing tasting CTA.

## Linear
- VNU-18: https://linear.app/zwergius/issue/VNU-18/rotate-top-banner-between-free-shipping-and-tasting-messages

## How to test
- pnpm exec prettier --check src/routes/+layout.svelte
- pnpm exec eslint src/routes/+layout.svelte
- pnpm check
- git diff --check
- Browser verified on http://localhost:5173/: free-shipping banner appears first in green, then rotates to the yellow tasting banner.

## Notes
- pnpm check reports existing unrelated warnings in hamburger-menu, +page, cookiepolitik, and om-os files.
- Svelte MCP tools referenced by AGENTS.md were not exposed in this session, so local Svelte checks were used instead.

## Risk
- Low; layout-only CTA rotation with existing colors and routes.

## Agent involvement
- Implemented and verified by Codex.