### PR TITLE
VNU-19 add Klaviyo onsite script

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -90,6 +90,55 @@
       }
     </script>
   {/if}
+  {#if !dev}
+    <script
+      async
+      type="text/javascript"
+      src="https://static.klaviyo.com/onsite/js/VzAU6H/klaviyo.js?company_id=VzAU6H"
+    ></script>
+    <script type="text/javascript">
+      !(function () {
+        if (!window.klaviyo) {
+          window._klOnsite = window._klOnsite || []
+          try {
+            window.klaviyo = new Proxy(
+              {},
+              {
+                get: function (n, i) {
+                  return 'push' === i
+                    ? function () {
+                        var n
+                        ;(n = window._klOnsite).push.apply(n, arguments)
+                      }
+                    : function () {
+                        for (var n = arguments.length, o = new Array(n), w = 0; w < n; w++)
+                          o[w] = arguments[w]
+                        var t = 'function' == typeof o[o.length - 1] ? o.pop() : void 0,
+                          e = new Promise(function (n) {
+                            window._klOnsite.push(
+                              [i].concat(o, [
+                                function (i) {
+                                  ;(t && t(i), n(i))
+                                },
+                              ]),
+                            )
+                          })
+                        return e
+                      }
+                },
+              },
+            )
+          } catch (n) {
+            ;((window.klaviyo = window.klaviyo || []),
+              (window.klaviyo.push = function () {
+                var n
+                ;(n = window._klOnsite).push.apply(n, arguments)
+              }))
+          }
+        }
+      })()
+    </script>
+  {/if}
 </svelte:head>
 
 {#snippet anchor(route: string, hasCartIcon?: true)}


### PR DESCRIPTION
## What changed

Added Klaviyo's onsite script and bootstrap snippet to the global SvelteKit head in src/routes/+layout.svelte. The script is scoped to non-dev runtime, matching the existing pattern for production third-party scripts.

## Why

Enables Klaviyo onsite initialization for the storefront.

## Linear

[VNU-19](https://linear.app/zwergius/issue/VNU-19/add-klaviyo-onsite-script)

## Acceptance criteria checked

- Klaviyo onsite script is included globally in the storefront head.
- The Klaviyo object bootstrap snippet is available on page load.
- The implementation follows existing SvelteKit layout/head patterns.
- Relevant checks passed.

## How to test

- pnpm check
- pnpm exec eslint --max-warnings=0 src/routes/+layout.svelte
- git diff --check

## Risk

Low. This adds a third-party marketing script in production-like runtime only. No custom Klaviyo event tracking was added.

## Not done

- No custom Klaviyo event tracking.
- No changes to CookieYes, Google Tag Manager, or analytics helpers.

## Agent involvement

Implemented and verified by Codex.
