### PR TITLE
[codex] VNU-18 keep top banner yellow

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,12 +16,10 @@
     {
       href: '/sortiment',
       text: 'Gratis fragt ved køb over 550 dkk',
-      variant: 'green',
     },
     {
       href: '/smagninger',
       text: 'Book en smagning',
-      variant: 'yellow',
     },
   ] as const
 
@@ -173,10 +171,7 @@
 
 <header class="sticky top-0 z-50 flex h-[--header-height] flex-col bg-brand-pink">
   <a
-    class="grid overflow-hidden py-1.5 text-center text-xs"
-    class:bg-green-600={topBanner.variant === 'green'}
-    class:bg-brand-yellow={topBanner.variant === 'yellow'}
-    class:text-white={topBanner.variant === 'green'}
+    class="grid overflow-hidden bg-brand-yellow py-1.5 text-center text-xs"
     href={topBanner.href}
     onblur={() => (isTopBannerPaused = false)}
     onfocus={() => (isTopBannerPaused = true)}


### PR DESCRIPTION
## What changed
- Keeps the rotating top banner messages and links from VNU-18.
- Removes the green free-shipping variant so both banner messages use the original yellow banner styling.

## Why
The free-shipping message should keep the existing top-banner visual treatment instead of introducing a green variant.

## Linear
VNU-18

## How to test
- pnpm exec prettier --check src/routes/+layout.svelte
- pnpm exec eslint src/routes/+layout.svelte
- pnpm check
- git diff --check

## Risk
Low. This only removes conditional color classes from the app shell banner.

## Not done
No checkout/CORS behavior changes were made.

## Agent involvement
Implemented by Codex.