### PR TITLE
[codex] Show Medusa sale prices

### DIFF
--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
   import { vermouths, type Handle } from '$lib/data/products'
   import { productSrcSet } from '$lib/helpers/images'
+  import { getProductPriceDisplay } from '$lib/helpers/prices'
+  import { resolve } from '$app/paths'
   import { HttpTypes } from '@medusajs/types'
 
-  const { product, onSelectItem }: { product: HttpTypes.StoreProduct; onSelectItem?: () => void } =
-    $props()
+  const {
+    currencyCode,
+    locale,
+    product,
+    onSelectItem,
+  }: {
+    currencyCode: string
+    locale: string
+    product: HttpTypes.StoreProduct
+    onSelectItem?: () => void
+  } = $props()
   const { image, origin } = $derived(vermouths[product.handle as Handle])
+  const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
 
   function handleSelectItem() {
     onSelectItem?.()
@@ -15,14 +27,14 @@
 <li class="grid-item aspect-[0.677/1] px-11 pb-7 pt-6 md:aspect-square md:py-6">
   <a
     class="flex h-full flex-col items-center"
-    href="/sortiment/{product.handle}"
+    href={resolve(`/sortiment/${product.handle}`)}
     onclick={handleSelectItem}
   >
     <h3 class="mb-2 whitespace-nowrap text-lg font-bold text-brand-blue md:mb-4">
       {product.title}
     </h3>
     <p class="whitespace-nowrap text-xs">{origin}</p>
-    <div class="flex flex-1 flex-col relative">
+    <div class="relative flex flex-1 flex-col">
       <img
         alt={product.title}
         class="my-auto w-auto md:max-h-44 lg:max-h-fit"
@@ -34,10 +46,33 @@
         height="290"
       />
       <div class="overlay">
-        <p class="btn whitespace-nowrap">LÆS MERE</p>
+        <p class="btn whitespace-nowrap">KØB NU</p>
       </div>
+      {#if priceDisplay?.savingsPercent}
+        <div
+          aria-label="Spar {priceDisplay.savingsPercent}%"
+          class="discount-badge absolute z-10 flex aspect-square flex-col items-center justify-center rounded-full bg-white text-center font-bold text-brand-red"
+        >
+          <span class="discount-label">SPAR</span>
+          <span class="discount-percent">{priceDisplay.savingsPercent}%</span>
+        </div>
+      {/if}
     </div>
-    <p class="text-xs">{product.subtitle}</p>
+    <div class="min-h-11 text-center text-xs">
+      <p>{product.subtitle}</p>
+      {#if priceDisplay}
+        <p class="mt-2 font-bold">
+          {#if priceDisplay.isDiscounted}
+            <span class="sr-only">Tilbudspris </span>{priceDisplay.current}
+            <span class="ml-1 font-normal line-through opacity-70">
+              <span class="sr-only">Normalpris </span>{priceDisplay.original}
+            </span>
+          {:else}
+            {priceDisplay.current}
+          {/if}
+        </p>
+      {/if}
+    </div>
   </a>
 </li>
 
@@ -58,6 +93,53 @@
     @apply absolute inset-y-0 flex flex-col justify-center left-1/2 -translate-x-1/2;
     opacity: 0;
     transition: opacity var(--filter-duration) ease-in-out;
+  }
+
+  .discount-badge {
+    left: 50%;
+    top: 40%;
+    width: clamp(5.25rem, 16vw, 6.75rem);
+    padding: 0.9rem;
+    gap: 0.8rem;
+    line-height: 0.9;
+    translate: calc(-128% - 60px) -112%;
+    scale: 0;
+    rotate: 8deg;
+    animation: discount-badge-pop 650ms cubic-bezier(0.16, 1.25, 0.32, 1) 180ms forwards;
+  }
+
+  .discount-label {
+    font-size: clamp(1rem, 0.85rem + 0.4vw, 1.25rem);
+    translate: 0 -0.1rem;
+    text-box: trim-both cap alphabetic;
+  }
+
+  .discount-percent {
+    font-size: clamp(1.55rem, 1.25rem + 0.75vw, 2.15rem);
+    text-box: trim-both cap alphabetic;
+  }
+
+  @keyframes discount-badge-pop {
+    0% {
+      scale: 0;
+      rotate: 8deg;
+    }
+    68% {
+      scale: 1.08;
+      rotate: -7deg;
+    }
+    100% {
+      scale: 1;
+      rotate: -10deg;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .discount-badge {
+      animation: none;
+      scale: 1;
+      rotate: -10deg;
+    }
   }
 
   @media (hover: hover) {

--- a/src/lib/helpers/prices.test.ts
+++ b/src/lib/helpers/prices.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { getProductPriceDisplay } from '$lib/helpers/prices'
+import type { HttpTypes } from '@medusajs/types'
+
+const formatDkk = new Intl.NumberFormat('da-DK', {
+  style: 'currency',
+  currency: 'dkk',
+  currencyDisplay: 'code',
+}).format
+
+function productWithPrice(
+  calculatedAmount?: number,
+  originalAmount?: number,
+): HttpTypes.StoreProduct {
+  return {
+    variants: [
+      {
+        calculated_price: {
+          calculated_amount: calculatedAmount,
+          original_amount: originalAmount,
+        },
+      },
+    ],
+  } as HttpTypes.StoreProduct
+}
+
+describe('getProductPriceDisplay', () => {
+  it('returns the sale price, original price, and savings percentage', () => {
+    expect(getProductPriceDisplay(productWithPrice(160, 200), 'dkk', 'da-DK')).toEqual({
+      current: formatDkk(160),
+      original: formatDkk(200),
+      savingsPercent: 20,
+      isDiscounted: true,
+    })
+  })
+
+  it('does not mark equal prices as discounted', () => {
+    expect(getProductPriceDisplay(productWithPrice(200, 200), 'dkk', 'da-DK')).toEqual({
+      current: formatDkk(200),
+      original: undefined,
+      savingsPercent: undefined,
+      isDiscounted: false,
+    })
+  })
+
+  it('returns null when Medusa did not calculate a price', () => {
+    expect(getProductPriceDisplay(productWithPrice(), 'dkk', 'da-DK')).toBeNull()
+  })
+})

--- a/src/lib/helpers/prices.ts
+++ b/src/lib/helpers/prices.ts
@@ -1,0 +1,45 @@
+import { formatPrice } from '$lib/helpers/numbers'
+import type { HttpTypes } from '@medusajs/types'
+
+type ProductVariant = NonNullable<HttpTypes.StoreProduct['variants']>[number]
+type CalculatedPrice = NonNullable<ProductVariant['calculated_price']> & {
+  calculated_amount?: number | null
+  original_amount?: number | null
+}
+
+export type ProductPriceDisplay = {
+  current: string
+  original?: string
+  savingsPercent?: number
+  isDiscounted: boolean
+}
+
+function toAmount(amount: number | null | undefined): number | null {
+  return typeof amount === 'number' ? amount : null
+}
+
+export function getProductPriceDisplay(
+  product: HttpTypes.StoreProduct,
+  currencyCode: string,
+  locale: string,
+): ProductPriceDisplay | null {
+  const price = product.variants?.[0]?.calculated_price as CalculatedPrice | undefined
+  const calculatedAmount = toAmount(price?.calculated_amount)
+
+  if (calculatedAmount === null) {
+    return null
+  }
+
+  const originalAmount = toAmount(price?.original_amount)
+  const isDiscounted = originalAmount !== null && originalAmount > calculatedAmount
+  const savingsPercent = isDiscounted
+    ? Math.round(((originalAmount - calculatedAmount) / originalAmount) * 100)
+    : undefined
+
+  return {
+    current: formatPrice(calculatedAmount, currencyCode, locale),
+    original: isDiscounted ? formatPrice(originalAmount, currencyCode, locale) : undefined,
+    savingsPercent,
+    isDiscounted,
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,8 +6,10 @@
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import Seo from '$lib/components/SEO.svelte'
   import Hero from '$lib/components/hero.svelte'
+  import { resolve } from '$app/paths'
 
   const { data }: PageProps = $props()
+  const { locale, region } = $derived(data)
 
   const founders = [
     {
@@ -60,7 +62,7 @@
     endnu. Fortvivl ikke! Lad os hjælpe dig med at<br />
     opdage og nyde vermouth.
   </p>
-  <a class="btn" href="/forhandlere">SE HVOR</a>
+  <a class="btn" href={resolve('/forhandlere')}>SE HVOR</a>
 </section>
 
 <Marquee text="VERMOUTH ER FOR ALLE //" theme="red"></Marquee>
@@ -71,14 +73,14 @@
     Rojo, Blanco, Orange eller Rosa?<br />
     Vi har det&nbsp;<span class="underline">hele</span>.
   </p>
-  <a class="btn" href="/sortiment">SE HELE UDVALGET</a>
+  <a class="btn" href={resolve('/sortiment')}>SE HELE UDVALGET</a>
 </section>
 
 <Marquee text="FAVORITTER //" theme="yellow"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each data.products as product}
-    <ProductGridItem {product} />
+  {#each data.products as product (product.id || product.handle)}
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
   {/each}
 </ul>
 
@@ -89,7 +91,7 @@
       <p class="mb-6 md:mb-8">
         Skift ginen ud:<br />Sådan laver du den perfekte vermouth & tonic og meget mere..
       </p>
-      <a class="btn" href="/inspiration">DRINKSOPSKRIFTER</a>
+      <a class="btn" href={resolve('/inspiration')}>DRINKSOPSKRIFTER</a>
     </div>
   </div>
 
@@ -121,12 +123,12 @@
       Med kærlighed til urterne og en drøm om at bringe ægte spansk vermouth til danske hjem,
       importerer vi nu de mest udsøgte flasker, der emmer af spansk charme og passion. ¡Salud!
     </p>
-    <a class="btn" href="/om-os">LÆS MERE</a>
+    <a class="btn" href={resolve('/om-os')}>LÆS MERE</a>
   </div>
 </section>
 
 <ul class="founding-fathers md:grid md:grid-cols-3 border-b border-black">
-  {#each founders as { name, imgUrl }}
+  {#each founders as { name, imgUrl } (name)}
     <li class="relative aspect-square">
       <img
         alt={name}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,11 +2,14 @@ import type { PageLoad } from './$types'
 import { sdk } from '$lib/medusa/index'
 import { dev } from '$app/environment'
 
-export const load: PageLoad = async () => {
+export const load: PageLoad = async ({ parent }) => {
+  const { region } = await parent()
   const data = await sdk.store.product.list({
     limit: 3,
     offset: 0,
     collection_id: dev ? 'pcol_01K9M5TBX8RNQFARPASPH3ASKM' : 'pcol_01KNKSM0FQXSFMJ4VE3KJMF43S',
+    fields: '*variants.calculated_price',
+    region_id: region.id,
   })
   return {
     products: data.products,

--- a/src/routes/sortiment/+page.svelte
+++ b/src/routes/sortiment/+page.svelte
@@ -12,6 +12,7 @@
     trackViewItemList,
     type GaListItem,
   } from '$lib/helpers/analytics'
+  import { resolve } from '$app/paths'
   import type { HttpTypes } from '@medusajs/types'
 
   const { data }: PageProps = $props()
@@ -19,6 +20,7 @@
   const white = $derived.by(() => data.categories.white)
   const other = $derived.by(() => data.categories.other)
   const packs = $derived.by(() => data.categories.packs)
+  const { locale, region } = $derived(data)
   const currency = $derived(data.region.currency_code.toUpperCase())
 
   type CategoryHandle = keyof typeof GA_CATEGORY_LABEL_BY_HANDLE
@@ -93,14 +95,19 @@
 <section class="content border-b border-black">
   <h1>VIL DU SMAGE FØR DU KØBER?</h1>
   <p>Så frygt ej! Du kan smage vores lækre dråber på et udvalg af steder i København</p>
-  <a class="btn" href="/forhandlere">SE HVOR</a>
+  <a class="btn" href={resolve('/forhandlere')}>SE HVOR</a>
 </section>
 
 <Marquee text="ROJO // RØD //" theme="yellow"></Marquee>
 
 <ul class="grid-layout border-b border-black">
   {#each red as product, index (product.id || product.handle)}
-    <ProductGridItem {product} onSelectItem={() => handleSelectItem(index + 1, product)} />
+    <ProductGridItem
+      currencyCode={region.currency_code}
+      {locale}
+      {product}
+      onSelectItem={() => handleSelectItem(index + 1, product)}
+    />
   {/each}
 </ul>
 
@@ -108,7 +115,12 @@
 
 <ul class="grid-layout border-b border-black">
   {#each white as product, index (product.id || product.handle)}
-    <ProductGridItem {product} onSelectItem={() => handleSelectItem(index + 1, product)} />
+    <ProductGridItem
+      currencyCode={region.currency_code}
+      {locale}
+      {product}
+      onSelectItem={() => handleSelectItem(index + 1, product)}
+    />
   {/each}
 </ul>
 
@@ -116,7 +128,12 @@
 
 <ul class="grid-layout border-b border-black">
   {#each other as product, index (product.id || product.handle)}
-    <ProductGridItem {product} onSelectItem={() => handleSelectItem(index + 1, product)} />
+    <ProductGridItem
+      currencyCode={region.currency_code}
+      {locale}
+      {product}
+      onSelectItem={() => handleSelectItem(index + 1, product)}
+    />
   {/each}
 </ul>
 
@@ -124,7 +141,12 @@
 
 <ul class="grid-layout border-b border-black">
   {#each packs as product, index (product.id || product.handle)}
-    <ProductGridItem {product} onSelectItem={() => handleSelectItem(index + 1, product)} />
+    <ProductGridItem
+      currencyCode={region.currency_code}
+      {locale}
+      {product}
+      onSelectItem={() => handleSelectItem(index + 1, product)}
+    />
   {/each}
 </ul>
 
@@ -134,5 +156,5 @@
     Vermouth smagninger til både private og firmaer. Den helt rigtige måde at komme igang med
     vermouth på.
   </p>
-  <a class="btn" href="/smagninger">BOOK EN SMAGNING</a>
+  <a class="btn" href={resolve('/smagninger')}>BOOK EN SMAGNING</a>
 </section>

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -11,13 +11,14 @@
     type GaListItem,
   } from '$lib/helpers/analytics'
   import { squareSrcSet } from '$lib/helpers/images'
-  import { formatPrice } from '$lib/helpers/numbers'
+  import { getProductPriceDisplay } from '$lib/helpers/prices'
   import { Form, QuantitySelector } from '$lib/components/form-controls'
   import Marquee from '$lib/components/marquee.svelte'
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import ProductSliders from '$lib/components/product-sliders.svelte'
   import Seo from '$lib/components/SEO.svelte'
   import { page } from '$app/state'
+  import { resolve } from '$app/paths'
   import { untrack } from 'svelte'
 
   const { slug } = $derived(page.params)
@@ -29,9 +30,7 @@
   )
   const productDescription = $derived(product.description ?? '')
   const variant = $derived(product.variants?.[0])
-  const formattedPrice = $derived(
-    formatPrice(variant?.calculated_price?.calculated_amount ?? 0, region.currency_code, locale),
-  )
+  const priceDisplay = $derived(getProductPriceDisplay(product, region.currency_code, locale))
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant?.id))
   type QuantityActionSuccess = { success: true; quantity: number }
 
@@ -39,14 +38,14 @@
   let isFormSubmitting = $state(false)
 
   const buttonText = $derived.by(() => {
-    if (buttonState === 'loading') return 'VENT...'
+    if (isFormSubmitting && buttonState === 'default') return 'VENT...'
     if (buttonState === 'success') return cartItem ? 'OPDATERET!' : 'TILFØJET!'
     if (buttonState === 'error') return 'FEJL'
     return 'LÆG I KURV'
   })
 
   const buttonColorClass = $derived.by(() => {
-    if (buttonState === 'loading') return 'bg-brand-blue/70'
+    if (isFormSubmitting && buttonState === 'default') return 'bg-brand-blue/70'
     if (buttonState === 'success') return 'bg-green-600'
     if (buttonState === 'error') return 'bg-red-600'
     return 'bg-brand-blue'
@@ -118,14 +117,6 @@
   }
 
   $effect(() => {
-    if (isFormSubmitting && buttonState === 'default') {
-      buttonState = 'loading'
-    } else if (!isFormSubmitting && buttonState === 'loading') {
-      buttonState = 'default'
-    }
-  })
-
-  $effect(() => {
     void slug
 
     untrack(() => {
@@ -151,9 +142,23 @@
     <p class=" font-bold text-xs mb-4">{product.subtitle}</p>
     <h1 class="text-2xl mb-2">{product.title}</h1>
     <p class="font-bold text-xs mb-4">{origin}</p>
-    <p class="font-bold text-base mb-6">
-      {formattedPrice}
-    </p>
+    {#if priceDisplay}
+      <div class="mb-6">
+        <p class="text-base font-bold">
+          {#if priceDisplay.isDiscounted}
+            <span class="sr-only">Tilbudspris </span>{priceDisplay.current}
+            <span class="ml-2 text-sm font-normal line-through opacity-70">
+              <span class="sr-only">Normalpris </span>{priceDisplay.original}
+            </span>
+          {:else}
+            {priceDisplay.current}
+          {/if}
+        </p>
+        {#if priceDisplay.savingsPercent}
+          <p class="mt-1 text-xs font-bold text-brand-red">SPAR {priceDisplay.savingsPercent}%</p>
+        {/if}
+      </div>
+    {/if}
     <div class="mb-4">
       <Form
         action="/kurv?/addOrUpdateItemQuantity"
@@ -165,7 +170,7 @@
         <div class="flex items-center justify-between md:gap-4">
           <button
             class="btn transition-colors duration-300 min-w-48 justify-center {buttonColorClass}"
-            disabled={buttonState !== 'default'}
+            disabled={buttonState !== 'default' || isFormSubmitting}
             type="submit"
           >
             {buttonText}
@@ -178,7 +183,7 @@
       class="block text-xs italic
       mb-10
       hover:font-bold"
-      href="/forhandlere">KØB ELLER SMAG HER &#8594;</a
+      href={resolve('/forhandlere')}>KØB ELLER SMAG HER &#8594;</a
     >
     <h3 class="text-sm font-bold mb-4">{product.subtitle}</h3>
     <p class="text-sm mb-6">{productDescription}</p>
@@ -239,14 +244,14 @@
 <section class="content md:hidden border-b border-black">
   <h2>VIL DU SMAGE FØR DU KØBER SÅ FRYGT EJ!</h2>
   <p>Du kan smage vores lækre dråber på et udvalg af barer & restauranter i København</p>
-  <a class="btn" href="/inspiration">SE HVOR</a>
+  <a class="btn" href={resolve('/inspiration')}>SE HVOR</a>
 </section>
 
 <Marquee text="ROJO // RØD //" theme="yellow"></Marquee>
 
 <ul class="grid-layout border-b border-black">
   {#each red as product (product.id)}
-    <ProductGridItem {product} />
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
   {/each}
 </ul>
 
@@ -254,7 +259,7 @@
 
 <ul class="grid-layout border-b border-black">
   {#each white as product (product.id)}
-    <ProductGridItem {product} />
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
   {/each}
 </ul>
 
@@ -262,7 +267,7 @@
 
 <ul class="grid-layout border-b border-black">
   {#each other as product (product.id)}
-    <ProductGridItem {product} />
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
   {/each}
 </ul>
 
@@ -270,7 +275,7 @@
 
 <ul class="grid-layout border-b border-black">
   {#each packs as product (product.id)}
-    <ProductGridItem {product} />
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
   {/each}
 </ul>
 
@@ -286,5 +291,5 @@
 <section class="content hidden md:block border-b border-black">
   <h2>Inspiration</h2>
   <p>Op dit cocktails-game med Vermouth</p>
-  <a class="btn" href="/inspiration">DYK NED I VORES MANGE DRINKSOPSKRIFTER</a>
+  <a class="btn" href={resolve('/inspiration')}>DYK NED I VORES MANGE DRINKSOPSKRIFTER</a>
 </section>


### PR DESCRIPTION
## What changed
- Added a shared Medusa calculated-price display helper with focused unit coverage.
- Show current sale price, original price, and savings for discounted products.
- Added the animated circular discount badge on product cards and changed the hover CTA to "KØB NU".
- Requested calculated prices for the home-page product fetch and passed locale/currency into product cards.
- Updated product detail pricing to use the same Medusa calculated-price display logic.

## Why
Some Medusa products now use sale pricing via price lists, including bundle-style products. The storefront needs to show those discounts consistently while checkout/cart pricing remains driven by Medusa.

## Linear
No Linear issue was provided.

## How to test
- Open /sortiment and verify discounted bundle products show the circular badge, sale price, and struck-through original price.
- Open a discounted product detail page and verify the sale/original price display.
- Confirm non-discounted products continue to show a single regular price.

## Validation
- pnpm exec vitest run src/lib/helpers/prices.test.ts
- pnpm check (0 errors; existing warnings remain)
- pnpm exec prettier --check on changed files
- pnpm exec eslint --max-warnings=0 on changed files
- git diff --check
- User visually verified the badge in the local browser.

## Risk
Low. Pricing display depends on Medusa's calculated_price response; checkout pricing remains owned by Medusa.

## Not done
- Did not change Medusa data or promotion/price-list configuration.
- Did not resolve unrelated existing Svelte warnings in other files.

## Agent involvement
Implemented and validated by Codex.