### PR TITLE
VNU-20 Add product reviews to product page

### DIFF
--- a/src/routes/api/products/[id]/reviews/+server.ts
+++ b/src/routes/api/products/[id]/reviews/+server.ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from './$types'
+import { json } from '@sveltejs/kit'
+import { PUBLIC_MEDUSA_PUBLISHABLE_KEY, PUBLIC_VITE_BACKEND_URL } from '$env/static/public'
+
+export const GET: RequestHandler = async ({ fetch, params, url }) => {
+  const query = new URLSearchParams({
+    limit: url.searchParams.get('limit') ?? '5',
+    offset: url.searchParams.get('offset') ?? '0',
+    order: url.searchParams.get('order') ?? '-created_at',
+  })
+  const fields = url.searchParams.get('fields')
+  const baseUrl = PUBLIC_VITE_BACKEND_URL.replace(/\/$/, '')
+
+  if (fields) {
+    query.set('fields', fields)
+  }
+
+  const response = await fetch(
+    `${baseUrl}/store/products/${encodeURIComponent(params.id)}/reviews?${query}`,
+    {
+      headers: {
+        'x-publishable-api-key': PUBLIC_MEDUSA_PUBLISHABLE_KEY,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    return json(
+      { message: 'Failed to fetch product reviews' },
+      {
+        status: response.status,
+      },
+    )
+  }
+
+  return json(await response.json())
+}

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -17,11 +17,18 @@
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import ProductSliders from '$lib/components/product-sliders.svelte'
   import Seo from '$lib/components/SEO.svelte'
+  import { replaceState } from '$app/navigation'
+  import { resolve } from '$app/paths'
   import { page } from '$app/state'
   import { untrack } from 'svelte'
 
   const { slug } = $derived(page.params)
   const { data }: PageProps = $props()
+  type ProductReviewsResponse = PageProps['data']['reviews']
+  type ProductReview = ProductReviewsResponse['reviews'][number]
+
+  const REVIEWS_PAGE_SIZE = 2
+
   const { red, white, other, packs } = $derived(data.categories)
   const { cart, locale, product, region } = $derived(data)
   const { extraImages, image, origin, recommendation, scores, taste } = $derived(
@@ -33,10 +40,25 @@
     formatPrice(variant?.calculated_price?.calculated_amount ?? 0, region.currency_code, locale),
   )
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant?.id))
+  let reviews = $derived(data.reviews)
+  let visibleReviews = $derived(data.reviews.reviews)
+  const averageRating = $derived(Math.round(reviews.average_rating * 10) / 10)
+  const formattedAverageRating = $derived(
+    new Intl.NumberFormat(locale, { maximumFractionDigits: 1 }).format(averageRating),
+  )
+  const hasReviews = $derived(reviews.review_count > 0)
+  const reviewCountLabel = $derived(
+    `${reviews.review_count} ${reviews.review_count === 1 ? 'anmeldelse' : 'anmeldelser'}`,
+  )
+  const visibleReviewCount = $derived(reviews.offset + visibleReviews.length)
+  const remainingReviewCount = $derived(Math.max(reviews.review_count - visibleReviewCount, 0))
+  const hasMoreReviews = $derived(remainingReviewCount > 0)
   type QuantityActionSuccess = { success: true; quantity: number }
 
   let buttonState = $state<'default' | 'loading' | 'success' | 'error'>('default')
   let isFormSubmitting = $state(false)
+  let isLoadingMoreReviews = $state(false)
+  let reviewsLoadError = $state(false)
 
   const buttonText = $derived.by(() => {
     if (buttonState === 'loading') return 'VENT...'
@@ -82,6 +104,77 @@
         ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
         : GA_MISSING.itemCategory,
       quantity,
+    }
+  }
+
+  function getRatingPercentage(rating: number) {
+    return `${Math.max(0, Math.min(5, rating)) * 20}%`
+  }
+
+  function formatReviewDate(date: string) {
+    return new Intl.DateTimeFormat(locale, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    }).format(new Date(date))
+  }
+
+  function updateReviewPaginationUrl(limit: number, offset: number) {
+    const currentSlug = slug ?? product.handle
+    if (!currentSlug) return
+
+    const nextUrl = new URL(page.url)
+    nextUrl.searchParams.set('reviews_limit', String(limit))
+    nextUrl.searchParams.set('reviews_offset', String(offset))
+    nextUrl.hash = 'product-reviews'
+    replaceState(
+      `${resolve('/sortiment/[slug=vermouth]', { slug: currentSlug })}${nextUrl.search}${nextUrl.hash}`,
+      page.state,
+    )
+  }
+
+  async function loadMoreReviews() {
+    if (!product.id || isLoadingMoreReviews || !hasMoreReviews) return
+
+    isLoadingMoreReviews = true
+    reviewsLoadError = false
+    const nextOffset = visibleReviewCount
+
+    const params = new URLSearchParams({
+      limit: String(REVIEWS_PAGE_SIZE),
+      offset: String(nextOffset),
+      order: '-created_at',
+    })
+
+    try {
+      const response = await fetch(
+        `/api/products/${encodeURIComponent(product.id)}/reviews?${params}`,
+      )
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch more product reviews')
+      }
+
+      const nextReviews = (await response.json()) as ProductReviewsResponse
+      const visibleReviewIds = new Set(visibleReviews.map((review) => review.id))
+      const mergedReviews: ProductReview[] = [
+        ...visibleReviews,
+        ...nextReviews.reviews.filter((review) => !visibleReviewIds.has(review.id)),
+      ]
+
+      visibleReviews = mergedReviews
+      reviews = {
+        ...nextReviews,
+        offset: reviews.offset,
+        limit: reviews.offset + mergedReviews.length,
+        reviews: mergedReviews,
+      }
+      updateReviewPaginationUrl(reviews.limit, reviews.offset)
+    } catch (error) {
+      console.error('load more product reviews failed with error: ', error)
+      reviewsLoadError = true
+    } finally {
+      isLoadingMoreReviews = false
     }
   }
 
@@ -148,6 +241,29 @@
 
 <section class="split-content border-b border-black lg:flex-row-reverse">
   <div class="copy">
+    {#if hasReviews}
+      <div class="mb-8 flex flex-col items-start gap-3 text-brand-blue">
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <p
+            class="relative inline-block text-[1.9375rem]/[1.9375rem] font-bold tracking-normal"
+            aria-label="{formattedAverageRating} ud af 5 stjerner"
+          >
+            <span aria-hidden="true" class="text-brand-blue/25">★★★★★</span>
+            <span
+              aria-hidden="true"
+              class="absolute inset-y-0 left-0 overflow-hidden whitespace-nowrap text-brand-blue"
+              style:width={getRatingPercentage(reviews.average_rating)}
+            >
+              ★★★★★
+            </span>
+          </p>
+          <p class="text-xs font-bold text-black">{reviewCountLabel}</p>
+        </div>
+        <a class="text-xs font-bold underline underline-offset-2" href="#product-reviews">
+          Læs {reviewCountLabel}
+        </a>
+      </div>
+    {/if}
     <p class=" font-bold text-xs mb-4">{product.subtitle}</p>
     <h1 class="text-2xl mb-2">{product.title}</h1>
     <p class="font-bold text-xs mb-4">{origin}</p>
@@ -178,7 +294,7 @@
       class="block text-xs italic
       mb-10
       hover:font-bold"
-      href="/forhandlere">KØB ELLER SMAG HER &#8594;</a
+      href={resolve('/forhandlere')}>KØB ELLER SMAG HER &#8594;</a
     >
     <h3 class="text-sm font-bold mb-4">{product.subtitle}</h3>
     <p class="text-sm mb-6">{productDescription}</p>
@@ -236,10 +352,81 @@
   </li>
 </ul>
 
+{#if hasReviews}
+  <section
+    class="border-b border-black px-11 py-12 text-brand-blue lg:px-20 lg:py-20 2xl:px-32"
+    id="product-reviews"
+  >
+    <div class="mb-12 flex items-end justify-between gap-6 border-b border-black pb-5">
+      <h2 class="text-base font-bold uppercase md:text-lg">SMAGT &amp; VURDERET</h2>
+      <div class="text-right">
+        <p
+          class="text-xl font-bold md:text-[3rem]/[3.5rem]"
+          aria-label="{formattedAverageRating} ud af 5 stjerner"
+        >
+          {formattedAverageRating}/5
+        </p>
+        <p class="text-xs font-bold text-black">{reviewCountLabel}</p>
+      </div>
+    </div>
+    <ul class="grid gap-10 lg:grid-cols-2" id="product-review-list">
+      {#each visibleReviews as review (review.id)}
+        <li
+          class="grid gap-4 border-t border-black pt-6 first:border-t-0 lg:[&:nth-child(-n+2)]:border-t-0"
+        >
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+            <p
+              class="relative inline-block text-[1.5rem]/[1.5rem] font-bold"
+              aria-label="{review.rating} ud af 5 stjerner"
+            >
+              <span aria-hidden="true" class="text-brand-blue/25">★★★★★</span>
+              <span
+                aria-hidden="true"
+                class="absolute inset-y-0 left-0 overflow-hidden whitespace-nowrap text-brand-blue"
+                style:width={getRatingPercentage(review.rating)}
+              >
+                ★★★★★
+              </span>
+            </p>
+            <p class="text-xs font-bold text-black">{formatReviewDate(review.created_at)}</p>
+          </div>
+          {#if review.title}
+            <h3 class="text-sm font-bold text-black">{review.title}</h3>
+          {/if}
+          {#if review.content}
+            <p class="max-w-[40rem] text-sm text-black">{review.content}</p>
+          {/if}
+          {#if review.reviewer_name}
+            <p class="text-xs font-bold text-black">- {review.reviewer_name}</p>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+    {#if hasMoreReviews}
+      <div class="mt-12 flex justify-center">
+        <button
+          class="btn justify-center transition-colors disabled:cursor-not-allowed disabled:bg-brand-blue/60"
+          type="button"
+          disabled={isLoadingMoreReviews}
+          onclick={loadMoreReviews}
+          aria-controls="product-review-list"
+        >
+          {isLoadingMoreReviews ? 'HENTER...' : `VIS FLERE (${remainingReviewCount})`}
+        </button>
+      </div>
+    {/if}
+    {#if reviewsLoadError}
+      <p class="mt-4 text-center text-xs font-bold text-black" aria-live="polite">
+        Kunne ikke hente flere anmeldelser. Prøv igen.
+      </p>
+    {/if}
+  </section>
+{/if}
+
 <section class="content md:hidden border-b border-black">
   <h2>VIL DU SMAGE FØR DU KØBER SÅ FRYGT EJ!</h2>
   <p>Du kan smage vores lækre dråber på et udvalg af barer & restauranter i København</p>
-  <a class="btn" href="/inspiration">SE HVOR</a>
+  <a class="btn" href={resolve('/inspiration')}>SE HVOR</a>
 </section>
 
 <Marquee text="ROJO // RØD //" theme="yellow"></Marquee>
@@ -286,5 +473,5 @@
 <section class="content hidden md:block border-b border-black">
   <h2>Inspiration</h2>
   <p>Op dit cocktails-game med Vermouth</p>
-  <a class="btn" href="/inspiration">DYK NED I VORES MANGE DRINKSOPSKRIFTER</a>
+  <a class="btn" href={resolve('/inspiration')}>DYK NED I VORES MANGE DRINKSOPSKRIFTER</a>
 </section>

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -130,16 +130,11 @@
     nextSearchParams.set('reviews_offset', String(reviews.offset))
 
     try {
-      await goto(
-        resolve(
-          `/sortiment/${encodeURIComponent(currentSlug)}?${nextSearchParams}#product-reviews`,
-        ),
-        {
-          keepFocus: true,
-          noScroll: true,
-          replaceState: true,
-        },
-      )
+      await goto(resolve(`/sortiment/${encodeURIComponent(currentSlug)}?${nextSearchParams}`), {
+        keepFocus: true,
+        noScroll: true,
+        replaceState: true,
+      })
     } catch (error) {
       console.error('load more product reviews failed with error: ', error)
       reviewsLoadError = true

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -17,15 +17,13 @@
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import ProductSliders from '$lib/components/product-sliders.svelte'
   import Seo from '$lib/components/SEO.svelte'
-  import { replaceState } from '$app/navigation'
+  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
   import { untrack } from 'svelte'
 
   const { slug } = $derived(page.params)
   const { data }: PageProps = $props()
-  type ProductReviewsResponse = PageProps['data']['reviews']
-  type ProductReview = ProductReviewsResponse['reviews'][number]
 
   const REVIEWS_PAGE_SIZE = 2
 
@@ -38,8 +36,8 @@
   const variant = $derived(product.variants?.[0])
   const priceDisplay = $derived(getProductPriceDisplay(product, region.currency_code, locale))
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant?.id))
-  let reviews = $derived(data.reviews)
-  let visibleReviews = $derived(data.reviews.reviews)
+  const reviews = $derived(data.reviews)
+  const visibleReviews = $derived(data.reviews.reviews)
   const averageRating = $derived(Math.round(reviews.average_rating * 10) / 10)
   const formattedAverageRating = $derived(
     new Intl.NumberFormat(locale, { maximumFractionDigits: 1 }).format(averageRating),
@@ -117,57 +115,31 @@
     }).format(new Date(date))
   }
 
-  function updateReviewPaginationUrl(limit: number, offset: number) {
-    const currentSlug = slug ?? product.handle
-    if (!currentSlug) return
-
-    const nextUrl = new URL(page.url)
-    nextUrl.searchParams.set('reviews_limit', String(limit))
-    nextUrl.searchParams.set('reviews_offset', String(offset))
-    nextUrl.hash = 'product-reviews'
-    replaceState(
-      `${resolve('/sortiment/[slug=vermouth]', { slug: currentSlug })}${nextUrl.search}${nextUrl.hash}`,
-      page.state,
-    )
-  }
-
   async function loadMoreReviews() {
-    if (!product.id || isLoadingMoreReviews || !hasMoreReviews) return
+    const currentSlug = slug ?? product.handle
+    if (!currentSlug || isLoadingMoreReviews || !hasMoreReviews) return
 
     isLoadingMoreReviews = true
     reviewsLoadError = false
-    const nextOffset = visibleReviewCount
-
-    const params = new URLSearchParams({
-      limit: String(REVIEWS_PAGE_SIZE),
-      offset: String(nextOffset),
-      order: '-created_at',
-    })
+    const nextSearchParams = new URLSearchParams(page.url.searchParams)
+    const maxVisibleReviews = Math.max(reviews.review_count - reviews.offset, 0)
+    nextSearchParams.set(
+      'reviews_limit',
+      String(Math.min(visibleReviews.length + REVIEWS_PAGE_SIZE, maxVisibleReviews)),
+    )
+    nextSearchParams.set('reviews_offset', String(reviews.offset))
 
     try {
-      const response = await fetch(
-        `/api/products/${encodeURIComponent(product.id)}/reviews?${params}`,
+      await goto(
+        resolve(
+          `/sortiment/${encodeURIComponent(currentSlug)}?${nextSearchParams}#product-reviews`,
+        ),
+        {
+          keepFocus: true,
+          noScroll: true,
+          replaceState: true,
+        },
       )
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch more product reviews')
-      }
-
-      const nextReviews = (await response.json()) as ProductReviewsResponse
-      const visibleReviewIds = new Set(visibleReviews.map((review) => review.id))
-      const mergedReviews: ProductReview[] = [
-        ...visibleReviews,
-        ...nextReviews.reviews.filter((review) => !visibleReviewIds.has(review.id)),
-      ]
-
-      visibleReviews = mergedReviews
-      reviews = {
-        ...nextReviews,
-        offset: reviews.offset,
-        limit: reviews.offset + mergedReviews.length,
-        reviews: mergedReviews,
-      }
-      updateReviewPaginationUrl(reviews.limit, reviews.offset)
     } catch (error) {
       console.error('load more product reviews failed with error: ', error)
       reviewsLoadError = true

--- a/src/routes/sortiment/[slug=vermouth]/+page.ts
+++ b/src/routes/sortiment/[slug=vermouth]/+page.ts
@@ -2,13 +2,76 @@ import type { PageLoad } from './$types'
 import { vermouths } from '$lib/data/products'
 import { error } from '@sveltejs/kit'
 import { sdk } from '$lib/medusa'
+
+type ProductReview = {
+  id: string
+  rating: number
+  title?: string | null
+  content?: string | null
+  reviewer_name?: string | null
+  created_at: string
+}
+
+type ProductReviewsResponse = {
+  reviews: ProductReview[]
+  average_rating: number
+  review_count: number
+  count: number
+  limit: number
+  offset: number
+}
+
+const emptyProductReviews: ProductReviewsResponse = {
+  reviews: [],
+  average_rating: 0,
+  review_count: 0,
+  count: 0,
+  limit: 0,
+  offset: 0,
+}
+
+const REVIEWS_PAGE_SIZE = 2
+const MAX_REVIEWS_LIMIT = 20
 const validSlugs = Object.keys(vermouths) as Array<keyof typeof vermouths>
 
-export const load: PageLoad = async ({ params, parent }) => {
+function getReviewPaginationParams(url: URL) {
+  const requestedLimit = Number(url.searchParams.get('reviews_limit'))
+  const requestedOffset = Number(url.searchParams.get('reviews_offset'))
+
+  return {
+    limit:
+      Number.isInteger(requestedLimit) && requestedLimit > 0
+        ? Math.min(requestedLimit, MAX_REVIEWS_LIMIT)
+        : REVIEWS_PAGE_SIZE,
+    offset: Number.isInteger(requestedOffset) && requestedOffset > 0 ? requestedOffset : 0,
+  }
+}
+
+async function getProductReviews(
+  productId: string,
+  fetcher: typeof fetch,
+  pagination: ReturnType<typeof getReviewPaginationParams>,
+) {
+  const params = new URLSearchParams({
+    limit: String(pagination.limit),
+    offset: String(pagination.offset),
+    order: '-created_at',
+  })
+  const response = await fetcher(`/api/products/${encodeURIComponent(productId)}/reviews?${params}`)
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch product reviews')
+  }
+
+  return response.json() as Promise<ProductReviewsResponse>
+}
+
+export const load: PageLoad = async ({ fetch, params, parent, url }) => {
   const vermouthSlug = params.slug as keyof typeof vermouths
   if (!validSlugs.includes(vermouthSlug))
     error(404, `Vermouth med id: ${params.slug} eksisterer ikke.`)
 
+  const reviewPagination = getReviewPaginationParams(url)
   const { region } = await parent()
   const data = await sdk.store.product.list({
     handle: params.slug,
@@ -17,8 +80,17 @@ export const load: PageLoad = async ({ params, parent }) => {
   })
 
   const vermouth = vermouths[vermouthSlug]
+  const product = data.products[0]
+  const reviews = product?.id
+    ? await getProductReviews(product.id, fetch, reviewPagination).catch((reviewsError) => {
+        console.error('product reviews fetch failed with error: ', reviewsError)
+        return emptyProductReviews
+      })
+    : emptyProductReviews
+
   return {
-    product: data.products[0],
+    product,
+    reviews,
     vermouth,
   }
 }

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -1,6 +1,41 @@
 import { expect, test } from '@playwright/test'
 import { vermouths } from '../src/lib/data/products'
 
+const productReviews = [
+  {
+    id: 'review-test-4',
+    rating: 4,
+    title: 'God med tonic og appelsin',
+    content: 'Super flot farve og god duft.',
+    reviewer_name: 'Testkunde D',
+    created_at: '2026-06-24T10:00:00.000Z',
+  },
+  {
+    id: 'review-test-3',
+    rating: 5,
+    title: 'Klar favorit til fredag',
+    content: 'Den har præcis den maritime friskhed jeg håbede på.',
+    reviewer_name: 'Testkunde C',
+    created_at: '2026-06-24T09:00:00.000Z',
+  },
+  {
+    id: 'review-test-2',
+    rating: 4,
+    title: 'Flot balance og god bitterhed',
+    content: 'Meget nem at servere direkte fra køleskabet.',
+    reviewer_name: 'Testkunde B',
+    created_at: '2026-06-24T08:00:00.000Z',
+  },
+  {
+    id: 'review-test-1',
+    rating: 5,
+    title: 'Perfekt til en stille aperitif',
+    content: 'Frisk, bitter og rund på den helt rigtige måde.',
+    reviewer_name: 'Testkunde A',
+    created_at: '2026-06-24T07:00:00.000Z',
+  },
+]
+
 const pages = [
   { path: '/', text: 'ENDNU IKKE FAN AF VERMOUTH?' },
   { path: '/sortiment', text: 'VIL DU SMAGE FØR DU KØBER?' },
@@ -39,4 +74,46 @@ test.describe('product detail pages', () => {
       await expect(page.getByRole('button', { name: 'LÆG I KURV' })).toBeVisible()
     })
   }
+
+  test('product reviews load more through URL pagination', async ({ page }) => {
+    const reviewRequests: Array<{ limit: string | null; offset: string | null }> = []
+
+    await page.route('**/api/products/*/reviews**', async (route) => {
+      const url = new URL(route.request().url())
+      const limit = Number(url.searchParams.get('limit') ?? '2')
+      const offset = Number(url.searchParams.get('offset') ?? '0')
+      reviewRequests.push({
+        limit: url.searchParams.get('limit'),
+        offset: url.searchParams.get('offset'),
+      })
+
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reviews: productReviews.slice(offset, offset + limit),
+          average_rating: 4.5,
+          review_count: productReviews.length,
+          count: productReviews.length,
+          limit,
+          offset,
+        }),
+      })
+    })
+
+    await page.goto('/sortiment', { waitUntil: 'networkidle' })
+    await page.locator('a[href="/sortiment/sardino-rojo"]').click()
+
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo$/)
+    await expect(page.locator('#product-review-list > li')).toHaveCount(2)
+    await expect(page.getByText('4 anmeldelser').first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'VIS FLERE (2)' })).toBeVisible()
+    expect(reviewRequests[0]).toEqual({ limit: '2', offset: '0' })
+
+    await page.getByRole('button', { name: 'VIS FLERE (2)' }).click()
+
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?reviews_limit=4&reviews_offset=0$/)
+    await expect(page.locator('#product-review-list > li')).toHaveCount(4)
+    await expect(page.getByRole('button', { name: /VIS FLERE/ })).toBeHidden()
+    expect(reviewRequests[1]).toEqual({ limit: '4', offset: '0' })
+  })
 })


### PR DESCRIPTION
## What changed
- Added a SvelteKit GET endpoint that proxies published product reviews from the Medusa Store API.
- Product pages now fetch and render review summary data, review cards, fractional star ratings, and review counts.
- Added paginated review loading with `reviews_limit` and `reviews_offset` preserved in the URL.
- Added a load-more flow for product reviews and adjusted review-card borders for the first row.

## Why
To show storefront product ratings and published customer reviews on product pages while keeping the initial render limited and shareable through URL state.

## Linear
VNU-20

## Acceptance criteria checked
- Sardino Rojo shows rating summary and review count in the top product area.
- Review section shows aggregate rating/count and initially limits visible reviews.
- `VIS FLERE` loads additional reviews and updates the URL pagination params.
- Reloading a URL with review pagination params preserves the visible review count.
- Fractional aggregate rating displays as 4.5/5 visually, not rounded to 5 stars.

## How to test
- `pnpm check`
- `git diff --check`
- Local browser verification on `/sortiment/sardino-rojo?reviews_limit=4&reviews_offset=0#product-reviews`

## Risk
Low to moderate. The UI is additive, but it depends on the backend review endpoint response shape and published review data being available.

## Intentionally not done
- POST/create-review storefront flow is not implemented.
- Review moderation/publishing remains backend-owned.

## Agent involvement
Implemented and verified with Codex.