### PR TITLE
VNU-21 support discount codes in cart

### DIFF
--- a/src/routes/kurv/+page.server.ts
+++ b/src/routes/kurv/+page.server.ts
@@ -29,6 +29,50 @@ function getAddressFields(data: FormData, isBillingAddress: boolean = false) {
 }
 
 export const actions = {
+  applyDiscountCode: async ({ cookies, request }) => {
+    const cart_id = cookies.get('cart_id')
+    if (!cart_id) return fail(404, { message: 'Missing cart_id' })
+
+    const data = await request.formData()
+    const discountCode = String(data.get('discount_code') ?? '')
+      .trim()
+      .toUpperCase()
+
+    if (!discountCode) {
+      return fail(400, {
+        action: 'discountCode',
+        discountCode,
+        message: 'Indtast en rabatkode.',
+      })
+    }
+
+    try {
+      const { cart } = await sdk.store.cart.retrieve(cart_id)
+      const currentPromoCodes =
+        cart.promotions?.flatMap(({ code, is_automatic }) =>
+          code && !is_automatic ? [code] : [],
+        ) ?? []
+
+      await sdk.store.cart.update(cart_id, {
+        promo_codes: [...new Set([...currentPromoCodes, discountCode])],
+      })
+
+      return {
+        action: 'discountCode',
+        discountCode,
+        message: 'Rabatkoden er tilføjet.',
+        success: true,
+      }
+    } catch (error) {
+      console.error('Error applying discount code', error)
+
+      return fail(400, {
+        action: 'discountCode',
+        discountCode,
+        message: 'Rabatkoden kunne ikke anvendes.',
+      })
+    }
+  },
   checkout: async ({ cookies, request }) => {
     const cartId = cookies.get('cart_id')
 

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -21,7 +21,7 @@
   import { formatPrice } from '$lib/helpers/numbers'
   import QuantitySelector from '$lib/components/form-controls/quantity-selector.svelte'
 
-  const { data }: PageProps = $props()
+  const { data, form }: PageProps = $props()
   const { cart, locale, region, shippingOptions, shippingPrices } = $derived(data)
   let hasDifferentBillingAddress: 'yes' | 'no' = $state('no')
   let selectedShippingMethodId = $derived(
@@ -39,13 +39,30 @@
     hasCartShippingMethod ? cart.total : cart.total + (displayedShippingTotal ?? 0),
   )
   let isSubmitting = $state(false)
+  let discountCodeMessage = $state('')
+  let discountCodeState = $state<'idle' | 'success' | 'error'>('idle')
   let hasCheckoutRedirected = $state(false)
   const checkoutState = $derived<'idle' | 'processing' | 'redirecting'>(
     hasCheckoutRedirected ? 'redirecting' : isSubmitting ? 'processing' : 'idle',
   )
   const analyticsCurrencyCode = $derived(region.currency_code.toUpperCase())
+  const appliedPromoCodes = $derived(
+    cart.promotions?.flatMap(({ code, is_automatic }) => (code && !is_automatic ? [code] : [])) ??
+      [],
+  )
+  const discountCodeFormData = $derived(getDiscountCodeFormData())
+  const displayedDiscountCodeMessage = $derived(
+    discountCodeMessage || discountCodeFormData?.message || '',
+  )
+  const displayedDiscountCodeState = $derived(getDisplayedDiscountCodeState())
 
   type QuantityActionSuccess = { success: true; quantity: number }
+  type DiscountCodeActionData = {
+    action: 'discountCode'
+    discountCode?: string
+    message?: string
+    success?: true
+  }
   type CartItemAnalyticsContext = {
     cartItemId: string
     productHandle?: string
@@ -72,10 +89,37 @@
     isSubmitting = false
   }
 
+  function getDiscountCodeFormData() {
+    return form?.action === 'discountCode' ? (form as DiscountCodeActionData) : null
+  }
+
+  function getDisplayedDiscountCodeState() {
+    if (discountCodeState !== 'idle') return discountCodeState
+    if (!discountCodeFormData) return 'idle'
+    if (discountCodeFormData.success) return 'success'
+
+    return 'error'
+  }
+
+  function handleDiscountCodeResult(result: ActionResult) {
+    if (result.type !== 'success' && result.type !== 'failure') return
+
+    const resultData = result.data as DiscountCodeActionData
+    if (resultData.action !== 'discountCode') return
+
+    discountCodeMessage = resultData.message ?? ''
+    discountCodeState = result.type === 'success' ? 'success' : 'error'
+  }
+
   function formattedPrice(price: number | undefined) {
     if (price === undefined) return ''
     if (price === 0) return 'Gratis'
     return formatPrice(price, region.currency_code, locale)
+  }
+
+  function formattedDiscount(price: number | undefined) {
+    if (!price) return ''
+    return `-${formattedPrice(price)}`
   }
 
   function getShippingOptionPrice(option?: { amount?: number | null; id: string }) {
@@ -262,12 +306,64 @@
     {/each}
   </ul>
   {#if cart}
-    <div class="p-5">
-      <dl class="flex flex-col gap-5 text-sm font-bold mb-2 lg:mb-0">
+    <div class="p-5" data-testid="cart-summary">
+      <div class="border-b border-black pb-3 mb-5">
+        <Form action="?/applyDiscountCode" onResult={handleDiscountCodeResult}>
+          <div class="flex flex-col gap-1">
+            <div class="flex flex-col gap-4 sm:flex-row lg:flex-col xl:flex-row">
+              <div class="relative min-w-0 flex-1">
+                <input
+                  aria-describedby={displayedDiscountCodeMessage
+                    ? 'discount-code-message'
+                    : undefined}
+                  autocomplete="off"
+                  class="peer min-h-14 w-full border-b border-black bg-transparent pt-7 pb-2 text-sm uppercase placeholder:text-transparent focus:outline-none"
+                  id="discount-code"
+                  name="discount_code"
+                  placeholder="Rabatkode"
+                  required
+                  type="text"
+                  value={discountCodeFormData?.discountCode ?? appliedPromoCodes[0] ?? ''}
+                />
+                <label
+                  class="pointer-events-none absolute left-0 top-0 text-sm duration-100 ease-linear peer-placeholder-shown:top-5 peer-placeholder-shown:text-gray-500 peer-focus:top-0 peer-focus:text-black"
+                  for="discount-code"
+                >
+                  Rabatkode
+                </label>
+              </div>
+              <button
+                class="btn mt-auto items-center justify-center px-5 py-2 text-sm leading-none"
+                type="submit"
+              >
+                Anvend
+              </button>
+            </div>
+            <p
+              class={[
+                'min-h-3 text-xs leading-none',
+                displayedDiscountCodeMessage ? 'visible' : 'invisible',
+                displayedDiscountCodeState === 'error' ? 'text-brand-red' : 'text-brand-blue',
+              ]}
+              id="discount-code-message"
+              role={displayedDiscountCodeState === 'error' ? 'alert' : 'status'}
+            >
+              {displayedDiscountCodeMessage || 'Rabatkode status'}
+            </p>
+          </div>
+        </Form>
+      </div>
+      <dl class="flex flex-col gap-5 text-sm font-bold mb-2 lg:mb-0" data-testid="cart-totals">
         <div class="flex justify-between">
           <dt>Subtotal</dt>
           <dd>{formattedPrice(cart?.item_total)}</dd>
         </div>
+        {#if cart.discount_total}
+          <div class="flex justify-between text-brand-red">
+            <dt>Rabat</dt>
+            <dd>{formattedDiscount(cart.discount_total)}</dd>
+          </div>
+        {/if}
         <div class="flex justify-between">
           <dt>Levering</dt>
           <dd>{formattedPrice(displayedShippingTotal)}</dd>

--- a/tests/ecommerce-flow.spec.ts
+++ b/tests/ecommerce-flow.spec.ts
@@ -50,6 +50,31 @@ test('customer can add and remove a product from the cart', async ({ page }) => 
   await expect(productRow).toBeHidden()
 })
 
+test('customer can apply a discount code in the cart summary', async ({ page }) => {
+  await addProductToCart(page)
+  await page.goto('/kurv', { waitUntil: 'networkidle' })
+
+  const cartSummary = page.locator('[data-testid="cart-summary"]:visible')
+  const discountCodeInput = cartSummary.getByRole('textbox', { name: 'Rabatkode' })
+  const applyDiscountButton = cartSummary.getByRole('button', { name: 'Anvend' })
+  const totals = cartSummary.getByTestId('cart-totals')
+  const totalsBoxBeforeError = await totals.boundingBox()
+
+  await discountCodeInput.fill('not-a-code')
+  await applyDiscountButton.click()
+
+  await expect(cartSummary.getByText('Rabatkoden kunne ikke anvendes.')).toBeVisible()
+
+  const totalsBoxAfterError = await totals.boundingBox()
+  expect(totalsBoxAfterError?.y).toBe(totalsBoxBeforeError?.y)
+
+  await discountCodeInput.fill('test10')
+  await applyDiscountButton.click()
+
+  await expect(cartSummary.getByText('Rabatkoden er tilføjet.')).toBeVisible()
+  await expect(totals.locator('div').filter({ hasText: 'Rabat' })).toBeVisible()
+})
+
 test('customer can continue from cart to payment', async ({ page }) => {
   await addProductToCart(page)
   await page.goto('/kurv', { waitUntil: 'networkidle' })


### PR DESCRIPTION
## What changed
- Added a cart summary discount-code form on /kurv.
- Added a server action that normalizes promo codes and applies them through Medusa.
- Shows applied discount totals in the cart summary.
- Added Playwright coverage for invalid and valid discount-code flows, including no layout shift on error.

## Why
VNU-21: Customers need to enter Medusa discount codes during cart checkout.

## How to test
- pnpm exec prettier --check src/routes/kurv/+page.svelte
- pnpm exec eslint --max-warnings=0 src/routes/kurv/+page.svelte
- PLAYWRIGHT_BASE_URL=http://localhost:5173 pnpm exec playwright test tests/ecommerce-flow.spec.ts --grep "customer can apply a discount code"
- Pre-commit hooks ran npm run check, npm run check:lint, and npm run check:prettier -- --write

## Risk
Low. Changes are scoped to the cart route and one focused integration test.

## Agent involvement
Implemented with Codex.