### PR TITLE
[codex] Harden checkout CI gates

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,42 @@ permissions:
   pull-requests: read
 
 jobs:
+  quality:
+    name: Lint, Svelte check, and unit tests
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --depth=1 origin "${GITHUB_REF}"
+          git checkout --force FETCH_HEAD
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint checks
+        run: pnpm lint
+
+      - name: Run Svelte checks
+        run: pnpm check
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
   test-preview:
     name: Playwright on Cloudflare preview
     timeout-minutes: 30

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm test:integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,6 @@ You MUST use this tool whenever writing Svelte code before sending it to the use
 Generates a Svelte Playground link with the provided code.
 After completing the code, ask the user if they want a playground link. Only call this tool after user confirmation and NEVER if code was written to files in their project.
 
-
 ## Way Of Working
 
 ### Start Here: Required First Actions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "vermouth-nu",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=22",
+    "pnpm": "^10.0.0"
+  },
   "scripts": {
     "predev": "pnpm fix",
     "dev": "vite dev --host",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,12 +10,13 @@ const config: PlaywrightTestConfig = {
   webServer: externalBaseURL
     ? undefined
     : {
-        command: 'npm run build && npm run preview -- --port 5173',
+        command: 'npm run build && npm run preview -- --host localhost --port 5173',
         port: 5173,
         reuseExistingServer: true,
       },
   testDir: 'tests',
   testMatch: /(.+\.)?(test|spec)\.[jt]s/,
+  workers: 1,
 }
 
 export default config

--- a/src/routes/betaling/+page.server.ts
+++ b/src/routes/betaling/+page.server.ts
@@ -36,7 +36,7 @@ export const load: PageServerLoad = async ({ fetch, parent, url }) => {
     notificationUrl: `${PUBLIC_VITE_BACKEND_URL}/webhooks/epay`,
     pointOfSaleId: PUBLIC_POINT_OF_SALE_ID,
     reference: cart.id.replace('cart_', ''),
-    successUrl: `${url.origin}/betaling/success`,
+    successUrl: `${url.origin}/betaling/success?reference=\${transaction.reference}`,
   }
 
   // Setup the fetch options

--- a/src/routes/betaling/success/+page.server.ts
+++ b/src/routes/betaling/success/+page.server.ts
@@ -1,20 +1,33 @@
 import type { PageServerLoad } from './$types'
 import { redirect } from '@sveltejs/kit'
 import type { HttpTypes } from '@medusajs/types'
+import { sdk } from '$lib/medusa'
 
 // Extend StoreCart type to include order when fetched with *order.id fields
 type CartWithOrder = HttpTypes.StoreCart & {
   order?: { id: string }
 }
 
-export const load: PageServerLoad = async ({ cookies, url, parent }) => {
-  const cartId = cookies.get('cart_id')
+function cartIdFromPaymentReference(reference: string) {
+  return reference.startsWith('cart_') ? reference : `cart_${reference}`
+}
+
+export const load: PageServerLoad = async ({ cookies, url }) => {
+  const paymentReference = url.searchParams.get('reference')
+  const cartId = paymentReference
+    ? cartIdFromPaymentReference(paymentReference)
+    : cookies.get('cart_id')
+
   if (!cartId) {
     redirect(303, '/betaling/fejl')
   }
 
-  // Get cart from parent layout
-  const { cart } = await parent()
+  // Prefer the ePay transaction reference from the success URL so this route
+  // can find the paid cart even if the active shopping cart cookie has already
+  // been rotated by the root layout.
+  const { cart } = await sdk.store.cart.retrieve(cartId, {
+    fields: '+order.id',
+  })
   const cartWithOrder = cart as CartWithOrder
 
   // Check if cart is completed with order


### PR DESCRIPTION
## Summary

- Add a pre-push hook that runs the Playwright integration suite.
- Split CI into a fast quality job for lint, `svelte-check`, and unit tests, plus the existing Cloudflare preview Playwright job.
- Make local Playwright runs use `localhost:5173` and keep `reuseExistingServer` for already-running dev/preview servers.
- Include the ePay transaction reference in the success URL and resolve the paid cart directly from that reference before redirecting to the Danish order page.
- Add package `engines` for Node 22+ and pnpm 10 without pinning an exact `packageManager` version.

## Verification

- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm lint`
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm check`
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm test:unit`
- `git diff --check`
- Pre-push hook: `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm test:integration` — 36 passed

## Notes

- The checkout integration still stops at the hosted payment step to avoid creating real orders/emails in the preview environment.
- The success redirect now uses the payment reference when ePay returns to `/betaling/success`, which avoids relying on the active cart cookie after checkout completion.
