### PR TITLE
Configure repository guidance for engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,13 +37,27 @@ You MUST use this tool whenever writing Svelte code before sending it to the use
 Generates a Svelte Playground link with the provided code.
 After completing the code, ask the user if they want a playground link. Only call this tool after user confirmation and NEVER if code was written to files in their project.
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in Linear under the `vermouth-nu` team and `website` project. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The default five-role triage label vocabulary is used. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Domain documentation uses the single-context layout. See `docs/agents/domain.md`.
+
 ## Way Of Working
 
 ### Start Here: Required First Actions
 
 Before any coding or project edit, you must:
 
-1. For implementation work that changes product behavior or project scope, read [Linear](/Users/zwergius/.codex/LINEAR.md); if no issue is provided, ask whether to create one before editing.
+1. For implementation work that changes product behavior or project scope, follow `docs/agents/issue-tracker.md` and read [Linear](/Users/zwergius/.codex/LINEAR.md); if no issue is provided, ask whether to create one before editing.
 2. Read [Git](/Users/zwergius/.codex/GIT.md); confirm isolation and include the Linear ID in the branch name when present.
 3. For GitHub, PR, issue, or CI work, read [GitHub](/Users/zwergius/.codex/GITHUB.md).
 4. Confirm the branch is current with the repository default branch unless told otherwise.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,34 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence or suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions get resolved.
+
+## File structure
+
+This repository uses a single-context layout:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When output names a domain concept—in an issue title, refactor proposal, hypothesis, or test name—use the term defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept isn't in the glossary, reconsider whether the language fits the project or note the gap for `/domain-modeling`.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface it explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,26 @@
+# Issue tracker: Linear
+
+Issues and PRDs for this repo live in Linear. Use the Linear app tools for structured operations.
+
+## Scope
+
+- **Team:** `vermouth-nu`
+- **Project:** `website`
+- Resolve live Linear identifiers before making changes rather than guessing IDs.
+
+## Conventions
+
+- Read an issue, its linked specification, comments, and relevant relationships before acting.
+- Create project-work issues in the `vermouth-nu` team and `website` project.
+- Preserve existing issue context and prefer focused updates over creating duplicates.
+- Add comments for discussion and progress notes.
+- Change issue fields or workflow status only when requested.
+- Use Linear's current team workflow; this repo defines no additional status overrides.
+
+## When a skill says "publish to the issue tracker"
+
+Create a Linear issue in the `vermouth-nu` team and `website` project.
+
+## When a skill says "fetch the relevant ticket"
+
+Fetch the Linear issue by its identifier, including its description, comments, labels, relationships, and linked documents.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                   |
+| -------------------------- | -------------------- | ----------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue   |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent   |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation             |
+| `wontfix`                  | `wontfix`            | Will not be actioned                      |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+Edit the `Label in our tracker` column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## What changed

- Added repository configuration for the engineering skills.
- Configured Linear issue tracking for the `vermouth-nu` team and `website` project.
- Documented the default triage-label mapping and single-context domain-doc layout.
- Added a concise Agent skills index to `AGENTS.md` and linked it from the startup workflow.

## Why

The engineering skills need a stable, repository-local source for issue tracker, triage, and domain-document conventions.

## Linear

Not applicable. This is documentation-only repository setup and has no Linear issue.

## Acceptance criteria checked

- Linear team and project are explicit.
- The five default triage labels are mapped.
- Domain documentation uses the single-context layout.
- Existing project guidance remains in `AGENTS.md` without duplicating tracker details.

## Risk

Low. The change affects agent documentation only and does not alter application behavior.

## How to test

- Run `git diff --check`.
- Review the Markdown links, tracker scope, triage mapping, and domain layout.

## Intentionally not done

- No application code, tests, Linear issues, or tracker labels were changed.
- No domain context or ADR was created; those remain lazy artifacts.

## Agent involvement

Codex performed the setup, incorporated user-confirmed tracker choices, and ran separate standards and specification reviews before submission.

## Follow-up issues

None.
