### PR TITLE
Add catalog promotion purchase freeze

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,13 +2,13 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                   |
-| -------------------------- | -------------------- | ----------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue   |
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent   |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation             |
-| `wontfix`                  | `wontfix`            | Will not be actioned                      |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
 
 When a skill mentions a role, use the corresponding label string from this table.
 

--- a/docs/catalog-promotion-purchase-freeze.md
+++ b/docs/catalog-promotion-purchase-freeze.md
@@ -1,0 +1,27 @@
+# Catalog promotion purchase freeze
+
+The storefront supports a temporary purchase freeze for catalog promotions. Browsing and cart-line
+removal remain available while add/update cart actions, checkout submission, and payment creation
+are blocked in both the interface and server routes.
+
+## Activate
+
+1. Set the private runtime environment variable `PURCHASES_PAUSED=true` for the target deployment.
+2. Deploy the storefront configuration.
+3. Verify the pause notice is visible on a product page and the cart page.
+4. Verify product quantity/add controls and checkout controls are disabled.
+5. Verify a direct POST to the cart quantity and checkout actions returns a SvelteKit failure result
+   with status `503`.
+6. Verify a direct request to `/betaling` returns `503` and does not create an ePay payment.
+7. Run `pnpm test:purchase-freeze`.
+8. Begin the reviewed catalog promotion only after all checks pass.
+
+## Deactivate
+
+1. Complete the catalog, media, URL, price, cart, analytics, and email smoke checks.
+2. Set `PURCHASES_PAUSED=false` or remove the variable.
+3. Deploy the storefront configuration.
+4. Verify a representative product can be added to the cart and continued to payment.
+
+Purchases are enabled by default. Values other than a case-insensitive, whitespace-tolerant `true`
+do not activate the freeze.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "prettier --check . && eslint --max-warnings=0 .",
     "format": "prettier --write .",
     "test:integration": "playwright test",
+    "test:purchase-freeze": "PURCHASES_PAUSED=true playwright test tests/purchase-freeze.spec.ts",
     "test:unit": "vitest",
     "check:lint": "eslint --max-warnings=0",
     "check:prettier": "prettier -c",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ const externalBaseURL = process.env.PLAYWRIGHT_BASE_URL
 const baseURL = externalBaseURL ?? 'http://localhost:5173'
 
 const config: PlaywrightTestConfig = {
+  retries: externalBaseURL ? 1 : 0,
   use: {
     baseURL,
   },

--- a/src/lib/purchase-availability.ts
+++ b/src/lib/purchase-availability.ts
@@ -1,0 +1,2 @@
+export const PURCHASES_PAUSED_MESSAGE =
+  'Vi opdaterer butikken. Køb er midlertidigt sat på pause, men du kan stadig se sortimentet.'

--- a/src/lib/server/purchase-availability.test.ts
+++ b/src/lib/server/purchase-availability.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  arePurchasesPaused,
+  assertPurchasesAvailable,
+  getPurchasePausedActionFailure,
+} from './purchase-availability'
+
+describe('purchase availability', () => {
+  it.each([undefined, '', 'false', '0', 'yes'])(
+    'keeps purchases available when PURCHASES_PAUSED is %s',
+    (value) => {
+      expect(arePurchasesPaused({ PURCHASES_PAUSED: value })).toBe(false)
+      expect(getPurchasePausedActionFailure({ PURCHASES_PAUSED: value })).toBeNull()
+      expect(() => assertPurchasesAvailable({ PURCHASES_PAUSED: value })).not.toThrow()
+    },
+  )
+
+  it.each(['true', 'TRUE', ' true '])('pauses purchases when PURCHASES_PAUSED is %s', (value) => {
+    expect(arePurchasesPaused({ PURCHASES_PAUSED: value })).toBe(true)
+
+    const failure = getPurchasePausedActionFailure({ PURCHASES_PAUSED: value })
+    expect(failure).toMatchObject({
+      data: {
+        action: 'purchasePaused',
+      },
+      status: 503,
+    })
+
+    expect(() => assertPurchasesAvailable({ PURCHASES_PAUSED: value })).toThrow()
+  })
+})

--- a/src/lib/server/purchase-availability.ts
+++ b/src/lib/server/purchase-availability.ts
@@ -1,0 +1,24 @@
+import { env } from '$env/dynamic/private'
+import { error, fail } from '@sveltejs/kit'
+import { PURCHASES_PAUSED_MESSAGE } from '$lib/purchase-availability'
+
+type PrivateEnvironment = Record<string, string | undefined>
+
+export function arePurchasesPaused(environment: PrivateEnvironment = env) {
+  return environment.PURCHASES_PAUSED?.trim().toLowerCase() === 'true'
+}
+
+export function getPurchasePausedActionFailure(environment: PrivateEnvironment = env) {
+  if (!arePurchasesPaused(environment)) return null
+
+  return fail(503, {
+    action: 'purchasePaused' as const,
+    message: PURCHASES_PAUSED_MESSAGE,
+  })
+}
+
+export function assertPurchasesAvailable(environment: PrivateEnvironment = env) {
+  if (arePurchasesPaused(environment)) {
+    error(503, PURCHASES_PAUSED_MESSAGE)
+  }
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,5 +1,6 @@
 import type { LayoutServerLoad } from './$types'
 import { sdk } from '$lib/medusa'
+import { arePurchasesPaused } from '$lib/server/purchase-availability'
 import { HttpTypes } from '@medusajs/types'
 
 type CategoryHandle = 'red' | 'white' | 'other' | 'packs'
@@ -70,6 +71,7 @@ export const load: LayoutServerLoad = async ({ cookies, depends, locals }) => {
     cart,
     categories,
     locale: locals.locale,
+    purchasesPaused: arePurchasesPaused(),
     region: regions[0],
   }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
   import logo from '$lib/images/vermouth-nu-logo.svg'
   import { reduced_motion } from '$lib/actions/reduced-motion'
   import { initializeAnalytics } from '$lib/helpers/analytics'
+  import { PURCHASES_PAUSED_MESSAGE } from '$lib/purchase-availability'
   import CancelRequestForm from '$lib/components/cancel-request-form.svelte'
   import HamburgerMenu from '$lib/components/hamburger-menu.svelte'
   import ModalDialog from '$lib/components/modal-dialog.svelte'
@@ -34,7 +35,7 @@
   ] as const
 
   const { children, data }: LayoutProps = $props()
-  const { cart, locale } = $derived(data)
+  const { cart, locale, purchasesPaused } = $derived(data)
   let topBannerIndex = $state(0)
   let isTopBannerPaused = $state(false)
   let isCancellationRequestOpen = $state(false)
@@ -243,6 +244,15 @@
 </header>
 
 <main class="flex flex-1 flex-col">
+  {#if purchasesPaused}
+    <aside
+      aria-label="Midlertidig købspause"
+      class="border-b border-black bg-brand-blue px-4 py-3 text-center text-xs font-bold text-white"
+      data-testid="purchase-pause"
+    >
+      {PURCHASES_PAUSED_MESSAGE}
+    </aside>
+  {/if}
   {@render children()}
 </main>
 

--- a/src/routes/betaling/+page.server.ts
+++ b/src/routes/betaling/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from './$types'
 import { EPAY_API_KEY } from '$env/static/private'
 import { PUBLIC_POINT_OF_SALE_ID, PUBLIC_VITE_BACKEND_URL } from '$env/static/public'
+import { assertPurchasesAvailable } from '$lib/server/purchase-availability'
 import { redirect } from '@sveltejs/kit'
 
 interface EpayPayload {
@@ -20,6 +21,8 @@ interface EpayPayload {
 }
 
 export const load: PageServerLoad = async ({ fetch, parent, url }) => {
+  assertPurchasesAvailable()
+
   const { cart } = await parent()
 
   // Create headers for the payment request

--- a/src/routes/kurv/+page.server.ts
+++ b/src/routes/kurv/+page.server.ts
@@ -1,5 +1,6 @@
 import type { Actions } from './$types'
 import { sdk } from '$lib/medusa'
+import { getPurchasePausedActionFailure } from '$lib/server/purchase-availability'
 import { fail, redirect } from '@sveltejs/kit'
 
 function getAddressFields(data: FormData, isBillingAddress: boolean = false) {
@@ -74,6 +75,9 @@ export const actions = {
     }
   },
   checkout: async ({ cookies, request }) => {
+    const purchasePausedFailure = getPurchasePausedActionFailure()
+    if (purchasePausedFailure) return purchasePausedFailure
+
     const cartId = cookies.get('cart_id')
 
     if (!cartId) return fail(404, { message: 'Missing cart_id' })
@@ -109,6 +113,9 @@ export const actions = {
     // return { success: true }
   },
   addOrUpdateItemQuantity: async ({ cookies, request }) => {
+    const purchasePausedFailure = getPurchasePausedActionFailure()
+    if (purchasePausedFailure) return purchasePausedFailure
+
     const cart_id = cookies.get('cart_id')
     if (!cart_id) return fail(404, { message: 'Missing cart_id' })
 

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -22,7 +22,7 @@
   import QuantitySelector from '$lib/components/form-controls/quantity-selector.svelte'
 
   const { data, form }: PageProps = $props()
-  const { cart, locale, region, shippingOptions, shippingPrices } = $derived(data)
+  const { cart, locale, purchasesPaused, region, shippingOptions, shippingPrices } = $derived(data)
   let hasDifferentBillingAddress: 'yes' | 'no' = $state('no')
   let selectedShippingMethodId = $derived(
     cart.shipping_methods?.[0]?.shipping_option_id ?? shippingOptions[0]?.id ?? '',
@@ -265,13 +265,15 @@
                 unitPrice: unit_price,
               })}
             >
-              <input name="cart_item_id" type="hidden" value={id} />
-              <QuantitySelector
-                min={1}
-                name="quantity"
-                onchange={handleChangeQuantity}
-                value={quantity}
-              />
+              <fieldset disabled={purchasesPaused}>
+                <input name="cart_item_id" type="hidden" value={id} />
+                <QuantitySelector
+                  min={1}
+                  name="quantity"
+                  onchange={handleChangeQuantity}
+                  value={quantity}
+                />
+              </fieldset>
             </Form>
             <Form
               action="?/deleteItem"
@@ -479,62 +481,66 @@
   <div class="px-4 py-8 lg:copy">
     <h1 class="text-sm font-bold mb-4">Kontaktinformation</h1>
     <Form action="?/checkout" bind:isSubmitting onResult={handleCheckoutResult}>
-      <div class="flex flex-col gap-4 mb-12">
-        <Input
-          autocomplete="email"
-          label="E-mailadresse"
-          name="email"
-          required
-          type="email"
-          value={cart.email}
-        />
-        <Checkbox
-          checked={!!cart?.metadata?.accepts_newsletter}
-          label="Tilmeld dig vores nyhedsbrev"
-          name="acceptsNewsletter"
-        />
-      </div>
-      {@render formAddressFields('shipping')}
-      <div class="mb-12">
-        <RadioGroup
-          groupLabel="Faktureringsadresse"
-          name="different_billing_address"
-          options={[
-            { label: 'Samme addresse som leveringsadresse', value: 'no' },
-            { label: 'Brug en anden faktureringsadresse', value: 'yes' },
-          ]}
-          bind:selected={hasDifferentBillingAddress}
-          required
-        />
-      </div>
-      {#if hasDifferentBillingAddress === 'yes'}
-        {@render formAddressFields('billing')}
-      {/if}
-      <div class="mb-12">
-        <RadioGroup
-          groupLabel="Leveringsmetode"
-          name="shipping_method_id"
-          options={shippingOptions.map((option) => ({
-            description: option.type.description,
-            label: option.name,
-            price: formattedPrice(getShippingOptionPrice(option)),
-            value: option.id,
-          }))}
-          bind:selected={selectedShippingMethodId}
-          required
-        />
-      </div>
-      <h2 class="text-sm font-bold mb-4">Bekræft betingelser</h2>
-      <div class="flex flex-col gap-4 mb-12">
-        <Checkbox
-          checked={!!cart?.metadata?.accepts_terms}
-          label="Jeg accepterer handelsbetingelserne samt bekræfter, at jeg er over 18 år."
-          name="accepts_terms"
-          required
-          requiredErrorMessage="Du skal bekræfte handelsbetingelser for at fortsætte."
-        />
-      </div>
-      <button class="btn" type="submit">Gå til betaling</button>
+      <fieldset disabled={purchasesPaused}>
+        <div class="flex flex-col gap-4 mb-12">
+          <Input
+            autocomplete="email"
+            label="E-mailadresse"
+            name="email"
+            required
+            type="email"
+            value={cart.email}
+          />
+          <Checkbox
+            checked={!!cart?.metadata?.accepts_newsletter}
+            label="Tilmeld dig vores nyhedsbrev"
+            name="acceptsNewsletter"
+          />
+        </div>
+        {@render formAddressFields('shipping')}
+        <div class="mb-12">
+          <RadioGroup
+            groupLabel="Faktureringsadresse"
+            name="different_billing_address"
+            options={[
+              { label: 'Samme addresse som leveringsadresse', value: 'no' },
+              { label: 'Brug en anden faktureringsadresse', value: 'yes' },
+            ]}
+            bind:selected={hasDifferentBillingAddress}
+            required
+          />
+        </div>
+        {#if hasDifferentBillingAddress === 'yes'}
+          {@render formAddressFields('billing')}
+        {/if}
+        <div class="mb-12">
+          <RadioGroup
+            groupLabel="Leveringsmetode"
+            name="shipping_method_id"
+            options={shippingOptions.map((option) => ({
+              description: option.type.description,
+              label: option.name,
+              price: formattedPrice(getShippingOptionPrice(option)),
+              value: option.id,
+            }))}
+            bind:selected={selectedShippingMethodId}
+            required
+          />
+        </div>
+        <h2 class="text-sm font-bold mb-4">Bekræft betingelser</h2>
+        <div class="flex flex-col gap-4 mb-12">
+          <Checkbox
+            checked={!!cart?.metadata?.accepts_terms}
+            label="Jeg accepterer handelsbetingelserne samt bekræfter, at jeg er over 18 år."
+            name="accepts_terms"
+            required
+            requiredErrorMessage="Du skal bekræfte handelsbetingelser for at fortsætte."
+          />
+        </div>
+        <button class="btn" type="submit">
+          {purchasesPaused ? 'BETALING MIDLERTIDIGT PAUSET' : 'Gå til betaling'}
+        </button>
+      </fieldset>
     </Form>
   </div>
   <div

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -28,7 +28,7 @@
   const REVIEWS_PAGE_SIZE = 2
 
   const { red, white, other, packs } = $derived(data.categories)
-  const { cart, locale, product, region } = $derived(data)
+  const { cart, locale, product, purchasesPaused, region } = $derived(data)
   const { extraImages, image, origin, recommendation, scores, taste } = $derived(
     vermouths[product.handle as Handle],
   )
@@ -57,6 +57,7 @@
   let reviewsLoadError = $state(false)
 
   const buttonText = $derived.by(() => {
+    if (purchasesPaused) return 'KØB MIDLERTIDIGT PAUSET'
     if (isFormSubmitting && buttonState === 'default') return 'VENT...'
     if (buttonState === 'success') return cartItem ? 'OPDATERET!' : 'TILFØJET!'
     if (buttonState === 'error') return 'FEJL'
@@ -247,18 +248,20 @@
         bind:isSubmitting={isFormSubmitting}
         onResult={handleFormResult}
       >
-        <input name="variant_id" type="hidden" value={variant?.id} />
-        <input name="cart_item_id" type="hidden" value={cartItem?.id} />
-        <div class="flex items-center justify-between md:gap-4">
-          <button
-            class="btn transition-colors duration-300 min-w-48 justify-center {buttonColorClass}"
-            disabled={buttonState !== 'default' || isFormSubmitting}
-            type="submit"
-          >
-            {buttonText}
-          </button>
-          <QuantitySelector min={1} name="quantity" value={cartItem?.quantity} />
-        </div>
+        <fieldset disabled={purchasesPaused}>
+          <input name="variant_id" type="hidden" value={variant?.id} />
+          <input name="cart_item_id" type="hidden" value={cartItem?.id} />
+          <div class="flex items-center justify-between md:gap-4">
+            <button
+              class="btn transition-colors duration-300 min-w-48 justify-center {buttonColorClass}"
+              disabled={buttonState !== 'default' || isFormSubmitting}
+              type="submit"
+            >
+              {buttonText}
+            </button>
+            <QuantitySelector min={1} name="quantity" value={cartItem?.quantity} />
+          </div>
+        </fieldset>
       </Form>
     </div>
     <a

--- a/tests/ecommerce-flow.spec.ts
+++ b/tests/ecommerce-flow.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test, type Page } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
 
 const productName = 'Forzudo Rojo'
 const productPath = '/sortiment/forzudo-rojo'
@@ -31,8 +32,7 @@ test('customer can add and remove a product from the cart', async ({ page }) => 
   await expect(productRow.locator('input[name="quantity"]')).toHaveValue('1')
 
   const selectedShippingMethod = page
-    .locator('fieldset')
-    .filter({ hasText: 'Leveringsmetode' })
+    .getByRole('group', { name: 'Leveringsmetode', exact: true })
     .locator('label')
     .filter({ has: page.locator('input:checked') })
   const selectedShippingPrice = await selectedShippingMethod.locator('p').nth(1).innerText()
@@ -52,7 +52,7 @@ test('customer can add and remove a product from the cart', async ({ page }) => 
 
 test('customer can apply a discount code in the cart summary', async ({ page }) => {
   await addProductToCart(page)
-  await page.goto('/kurv', { waitUntil: 'networkidle' })
+  await page.goto('/kurv', { waitUntil: 'domcontentloaded' })
 
   const cartSummary = page.locator('[data-testid="cart-summary"]:visible')
   const discountCodeInput = cartSummary.getByRole('textbox', { name: 'Rabatkode' })
@@ -77,7 +77,7 @@ test('customer can apply a discount code in the cart summary', async ({ page }) 
 
 test('customer can continue from cart to payment', async ({ page }) => {
   await addProductToCart(page)
-  await page.goto('/kurv', { waitUntil: 'networkidle' })
+  await page.goto('/kurv', { waitUntil: 'domcontentloaded' })
 
   await expect(page.getByText(productName).first()).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Kontaktinformation' })).toBeVisible()

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,10 @@
+import { expect, test as base } from '@playwright/test'
+
+export { expect }
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route('https://static.klaviyo.com/**', (route) => route.abort())
+    await use(page)
+  },
+})

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test'
 import { vermouths } from '../src/lib/data/products'
+import { expect, test } from './fixtures'
 
 const cancellationRequestActionData =
   // SvelteKit serializes ActionResult data with devalue before use:enhance deserializes it.
@@ -120,7 +120,7 @@ test.describe('cancellation request flow', () => {
   })
 
   test('customer can submit a cancellation request from the footer dialog', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'networkidle' })
+    await page.goto('/', { waitUntil: 'load' })
 
     await page.locator('footer').getByRole('link', { name: 'Fortryd køb her' }).click()
 
@@ -140,7 +140,7 @@ test.describe('cancellation request flow', () => {
 
   test('customer can submit a cancellation request from the fallback page', async ({ page }) => {
     await page.goto('/ordrer/fortryd?email=kunde@example.com&orderReference=1001', {
-      waitUntil: 'networkidle',
+      waitUntil: 'domcontentloaded',
     })
 
     await expect(page.getByRole('heading', { name: 'Fortryd køb' })).toBeVisible()

--- a/tests/purchase-freeze.spec.ts
+++ b/tests/purchase-freeze.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test, type Page } from '@playwright/test'
+
+declare const process: {
+  env: Record<string, string | undefined>
+}
+
+const purchasesPaused = process.env.PURCHASES_PAUSED?.trim().toLowerCase() === 'true'
+
+function postDirectly(page: Page, url: string, form: Record<string, string> = {}) {
+  return page.evaluate(
+    async ({ form, url }) => {
+      const response = await fetch(url, {
+        body: new URLSearchParams(form),
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/x-www-form-urlencoded',
+          'x-sveltekit-action': 'true',
+        },
+        method: 'POST',
+      })
+      const result = (await response.json()) as {
+        status: number
+        type: string
+      }
+
+      return {
+        actionStatus: result.status,
+        actionType: result.type,
+        responseStatus: response.status,
+      }
+    },
+    { form, url },
+  )
+}
+
+test.describe('catalog promotion purchase freeze', () => {
+  test.skip(!purchasesPaused, 'Run with PURCHASES_PAUSED=true')
+
+  test('keeps browsing available and blocks purchase entry points', async ({ page }) => {
+    await page.goto('/sortiment/forzudo-rojo', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.getByTestId('purchase-pause')).toContainText(
+      'Køb er midlertidigt sat på pause',
+    )
+    await expect(page.getByRole('button', { name: 'KØB MIDLERTIDIGT PAUSET' })).toBeDisabled()
+
+    const variantId = await page.locator('input[name="variant_id"]').inputValue()
+    const addToCartResponse = await postDirectly(page, '/kurv?/addOrUpdateItemQuantity', {
+      quantity: '1',
+      variant_id: variantId,
+    })
+    expect(addToCartResponse).toEqual({
+      actionStatus: 503,
+      actionType: 'failure',
+      responseStatus: 200,
+    })
+
+    await page.goto('/kurv', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('button', { name: 'BETALING MIDLERTIDIGT PAUSET' })).toBeDisabled()
+
+    const checkoutResponse = await postDirectly(page, '/kurv?/checkout')
+    expect(checkoutResponse).toEqual({
+      actionStatus: 503,
+      actionType: 'failure',
+      responseStatus: 200,
+    })
+
+    const paymentResponse = await page.request.get('/betaling', { maxRedirects: 0 })
+    expect(paymentResponse.status()).toBe(503)
+  })
+})


### PR DESCRIPTION
## What changed

- add a private `PURCHASES_PAUSED` runtime flag, disabled by default
- show a storefront-wide Danish purchase-pause notice
- disable product add/update and checkout controls while paused
- enforce the pause server-side for cart mutations, checkout submission, and direct payment access
- keep catalog browsing and cart-line removal available
- document activation, verification, and deactivation steps
- add unit coverage and a focused Playwright purchase-freeze flow
- stabilize preview tests by isolating the external Klaviyo popup, using accessible shipping-group targeting, avoiding global network-idle waits, and retrying one external-preview network failure
- format the existing triage-label table exposed by the repository-wide CI lint check

## Why

Catalog promotions can temporarily leave Medusa and the storefront in an intentionally transitional state. This provides a controlled, reversible way to prevent new purchases during that window without taking the catalog offline.

Closes [VNU-36](https://linear.app/zwergius/issue/VNU-36/add-a-purchase-freeze-for-catalog-promotions).

## Acceptance criteria checked

- [x] browsing remains available
- [x] cart-line removal remains available
- [x] product add/update controls are disabled
- [x] checkout controls are disabled
- [x] direct cart add/update and checkout actions fail with status 503
- [x] direct `/betaling` access fails with HTTP 503 before payment creation
- [x] purchases remain enabled when the flag is absent or not `true`
- [x] activation and rollback/deactivation steps are documented

## How to test

```sh
pnpm lint
pnpm test:purchase-freeze
pnpm test:unit
pnpm check
pnpm build
PLAYWRIGHT_BASE_URL=<preview-url> pnpm test:integration
```

Manual activation uses the private runtime value `PURCHASES_PAUSED=true`. Verify the notice and disabled controls on a product page and `/kurv`, then remove the value or set it to `false` to restore purchases.

## Verification

- `pnpm lint` — passed
- `pnpm test:purchase-freeze` — passed (1 focused browser test)
- `pnpm test:unit` — passed (18 tests)
- `pnpm check` — passed (0 errors; 10 pre-existing warnings)
- `pnpm build` — passed
- full Cloudflare-preview Playwright suite — passed (36 tests; purchase-freeze-only test skipped because the preview flag is off)
- footer-dialog hydration scenario repeated five times — passed
- `git diff --check` — passed

The initial CI failures exposed three separate test issues: the purchase-freeze fieldset made a generic shipping locator ambiguous, the live Klaviyo form contaminated commerce locators and pointer events, and production-like third-party traffic made `networkidle` unsuitable as a readiness signal. A later one-off Cloudflare socket disconnect passed five immediate repetitions; external preview runs now allow one retry while local runs remain retry-free.

## Risk

Low and reversible. Purchases are enabled by default; only a case-insensitive, whitespace-tolerant `true` activates the pause. The primary operational risk is forgetting to remove the flag, mitigated by the documented deactivation checklist and prominent storefront notice. Test-only stabilization blocks Klaviyo only inside affected Playwright contexts and does not change production behavior.

## Preview

Desktop and mobile paused states were visually verified locally. Cloudflare preview access to Medusa is tracked separately in [VNU-37](https://linear.app/zwergius/issue/VNU-37/allow-cloudflare-pages-preview-origins-in-medusa-cors-configuration).

## Intentionally not included

- catalog migration implementation from VNU-32
- Medusa CORS configuration from VNU-37
- changes to cart-line removal or discount removal behavior

## Agent involvement

Implemented and verified with Codex. Scope and operational behavior were agreed interactively before implementation.