### PR TITLE
VNU-35: Implement Medusa-backed product variant selector

### DIFF
--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
-  export let description: string
-  export let image: string
-  export let imageAlt: string
-  export let title: string
+  const {
+    description,
+    image,
+    imageAlt,
+    title,
+    url,
+  }: {
+    description: string
+    image: string
+    imageAlt: string
+    title: string
+    url?: string
+  } = $props()
 </script>
 
 <svelte:head>
@@ -17,7 +26,7 @@
   <!-- <meta name="twitter:card" content="summary_large_image" /> -->
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
-  <meta name="twitter:url" content="website" />
+  <meta name="twitter:url" content={url ?? 'https://www.vermouth.nu'} />
   <meta name="twitter:image" content={image} />
   <meta name="twitter:image:alt" content={imageAlt} />
 
@@ -30,5 +39,5 @@
   <meta property="og:description" content={description} />
   <meta property="og:image" itemprop="image" content={image} />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.vermouth.nu" />
+  <meta property="og:url" content={url ?? 'https://www.vermouth.nu'} />
 </svelte:head>

--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -7,8 +7,8 @@
     url,
   }: {
     description: string
-    image: string
-    imageAlt: string
+    image?: string
+    imageAlt?: string
     title: string
     url?: string
   } = $props()
@@ -27,8 +27,10 @@
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
   <meta name="twitter:url" content={url ?? 'https://www.vermouth.nu'} />
-  <meta name="twitter:image" content={image} />
-  <meta name="twitter:image:alt" content={imageAlt} />
+  {#if image}
+    <meta name="twitter:image" content={image} />
+    {#if imageAlt}<meta name="twitter:image:alt" content={imageAlt} />{/if}
+  {/if}
 
   <!--  Essential META Tags -->
 
@@ -37,7 +39,7 @@
   <meta property="og:site_name" content="Vermouth.NU" />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
-  <meta property="og:image" itemprop="image" content={image} />
+  {#if image}<meta property="og:image" itemprop="image" content={image} />{/if}
   <meta property="og:type" content="website" />
   <meta property="og:url" content={url ?? 'https://www.vermouth.nu'} />
 </svelte:head>

--- a/src/lib/components/form-controls/radio-group.svelte
+++ b/src/lib/components/form-controls/radio-group.svelte
@@ -5,6 +5,7 @@
 
   interface RadioGroupProps extends HTMLInputAttributes {
     groupLabel: string
+    layout?: 'stacked' | 'responsive-grid'
     name: string
     onChange?: (e: Event & { currentTarget: HTMLInputElement }) => void
     options: Array<{ description?: string; label: string; price?: string; value: string }>
@@ -14,6 +15,7 @@
   let {
     disabled,
     groupLabel,
+    layout = 'stacked',
     name,
     onChange,
     options,
@@ -51,12 +53,12 @@
   }
 </script>
 
-<fieldset class="relative rounded" {disabled}>
+<fieldset class:responsive-grid={layout === 'responsive-grid'} class="relative rounded" {disabled}>
   <legend class="text-sm font-bold mb-4">
     <span class="">{groupLabel}</span>
   </legend>
   <ul class="border border-dark-blue">
-    {#each options as { description, label, price, value }}
+    {#each options as { description, label, price, value } (value)}
       <li class="border-b last-of-type:border-none border-dark-blue">
         <label
           class="relative pl-4 py-5 pr-24 flex items-center gap-4 bg-white/40 has-[:checked]:bg-black/20"
@@ -77,9 +79,9 @@
             {...restProps}
           />
           <div class="text-xs leading-normal flex-1">
-            <div class="flex justify-between font-semibold">
+            <div class="flex justify-between gap-3 font-semibold">
               <p>{label}</p>
-              <p>{price}</p>
+              <p class="ml-auto whitespace-nowrap text-right">{price}</p>
             </div>
             <p>{description}</p>
           </div>
@@ -107,3 +109,22 @@
     </p>
   {/if}
 </fieldset>
+
+<style>
+  fieldset.responsive-grid label {
+    padding-inline-end: 1rem;
+  }
+
+  @media (min-width: 1024px) {
+    fieldset.responsive-grid ul {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+      border: 0;
+    }
+
+    fieldset.responsive-grid li {
+      border: 1px solid currentColor;
+    }
+  }
+</style>

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -3,6 +3,8 @@
   import { productSrcSet } from '$lib/helpers/images'
   import {
     getDefaultVariant,
+    getEligibleVariants,
+    getPresentationImage,
     getVariantImage,
     getVariantImageAltText,
     getVariantLabel,
@@ -28,19 +30,25 @@
     vermouths[product.handle as Handle],
   )
   const defaultVariant = $derived(getDefaultVariant(product))
+  const eligibleVariantCount = $derived(getEligibleVariants(product).length)
   const presentation = $derived(getVariantPresentation(defaultVariant))
   const imageAltText = $derived(
     getVariantImageAltText(product.title, getVariantLabel(defaultVariant)),
   )
-  const storefrontImage = $derived(
+  const configuredImage = $derived(
     getVariantImage({
       fallbackAltText: imageAltText,
       variantSku: defaultVariant.sku,
       variantImages,
-    }) ?? {
-      altText: imageAltText,
-      url: image,
-    },
+    }),
+  )
+  const storefrontImage = $derived(
+    getPresentationImage({
+      configuredImage,
+      fallbackAltText: imageAltText,
+      fallbackImage: image,
+      variantCount: eligibleVariantCount,
+    }),
   )
   const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
   let isDiscountBadgeVisible = $state(false)
@@ -86,16 +94,20 @@
     </h3>
     <p class="whitespace-nowrap text-xs">{origin}</p>
     <div class="relative flex flex-1 flex-col">
-      <img
-        alt={storefrontImage.altText}
-        class="my-auto w-auto md:max-h-44 lg:max-h-fit"
-        loading="lazy"
-        srcset={productSrcSet(storefrontImage.url)}
-        src="{storefrontImage.url}/w=145,h=290,fit=cover"
-        sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
-        width="290"
-        height="290"
-      />
+      {#if storefrontImage}
+        <img
+          alt={storefrontImage.altText}
+          class="my-auto w-auto md:max-h-44 lg:max-h-fit"
+          loading="lazy"
+          srcset={productSrcSet(storefrontImage.url)}
+          src="{storefrontImage.url}/w=145,h=290,fit=cover"
+          sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
+          width="290"
+          height="290"
+        />
+      {:else}
+        <p class="my-auto text-center text-xs">{imageAltText}</p>
+      {/if}
       <div class="overlay">
         <p class="btn whitespace-nowrap">KØB NU</p>
       </div>

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -3,8 +3,9 @@
   import { productSrcSet } from '$lib/helpers/images'
   import {
     getDefaultVariant,
-    getEligibleVariants,
     getVariantImage,
+    getVariantImageAltText,
+    getVariantLabel,
     getVariantPresentation,
   } from '$lib/helpers/product-variants'
   import { getProductPriceDisplay } from '$lib/helpers/prices'
@@ -25,21 +26,19 @@
   } = $props()
   const { image, origin, variantImages } = $derived(vermouths[product.handle as Handle])
   const defaultVariant = $derived(getDefaultVariant(product))
-  const eligibleVariantCount = $derived(getEligibleVariants(product).length)
   const presentation = $derived(getVariantPresentation(defaultVariant))
+  const imageAltText = $derived(
+    getVariantImageAltText(product.title, getVariantLabel(defaultVariant)),
+  )
   const storefrontImage = $derived(
     getVariantImage({
+      fallbackAltText: imageAltText,
       variantSku: defaultVariant.sku,
       variantImages,
-    }) ??
-      (eligibleVariantCount === 1
-        ? {
-            altText: [product.title, presentation.packaging, presentation.size]
-              .filter(Boolean)
-              .join(' – '),
-            url: image,
-          }
-        : null),
+    }) ?? {
+      altText: imageAltText,
+      url: image,
+    },
   )
   const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
   let isDiscountBadgeVisible = $state(false)
@@ -85,26 +84,16 @@
     </h3>
     <p class="whitespace-nowrap text-xs">{origin}</p>
     <div class="relative flex flex-1 flex-col">
-      {#if storefrontImage}
-        <img
-          alt={storefrontImage.altText}
-          class="my-auto w-auto md:max-h-44 lg:max-h-fit"
-          loading="lazy"
-          srcset={productSrcSet(storefrontImage.url)}
-          src="{storefrontImage.url}/w=145,h=290,fit=cover"
-          sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
-          width="290"
-          height="290"
-        />
-      {:else}
-        <div
-          aria-label="{product.title}. Billede mangler."
-          class="my-auto grid aspect-square w-full place-items-center border border-black bg-white/40 p-4 text-center text-xs font-bold"
-          role="img"
-        >
-          Billede mangler
-        </div>
-      {/if}
+      <img
+        alt={storefrontImage.altText}
+        class="my-auto w-auto md:max-h-44 lg:max-h-fit"
+        loading="lazy"
+        srcset={productSrcSet(storefrontImage.url)}
+        src="{storefrontImage.url}/w=145,h=290,fit=cover"
+        sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
+        width="290"
+        height="290"
+      />
       <div class="overlay">
         <p class="btn whitespace-nowrap">KØB NU</p>
       </div>

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -24,7 +24,9 @@
     product: HttpTypes.StoreProduct
     onSelectItem?: () => void
   } = $props()
-  const { image, origin, variantImages } = $derived(vermouths[product.handle as Handle])
+  const { alcoholPercentage, image, origin, variantImages } = $derived(
+    vermouths[product.handle as Handle],
+  )
   const defaultVariant = $derived(getDefaultVariant(product))
   const presentation = $derived(getVariantPresentation(defaultVariant))
   const imageAltText = $derived(
@@ -115,7 +117,9 @@
     </div>
     <div class="min-h-11 text-center text-xs">
       <p>{product.subtitle}</p>
-      <p class="mt-1 font-bold">{presentation.packaging} · {presentation.size}</p>
+      <p class="mt-1 font-bold">
+        {presentation.packaging} · {presentation.size} · {alcoholPercentage}
+      </p>
       {#if priceDisplay}
         <p class="mt-2 font-bold">
           {#if priceDisplay.isDiscounted}

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
   import { vermouths, type Handle } from '$lib/data/products'
   import { productSrcSet } from '$lib/helpers/images'
+  import {
+    getDefaultVariant,
+    getEligibleVariants,
+    getVariantImage,
+    getVariantPresentation,
+  } from '$lib/helpers/product-variants'
   import { getProductPriceDisplay } from '$lib/helpers/prices'
   import { resolve } from '$app/paths'
-  import { HttpTypes } from '@medusajs/types'
+  import type { HttpTypes } from '@medusajs/types'
   import type { Attachment } from 'svelte/attachments'
 
   const {
@@ -17,7 +23,21 @@
     product: HttpTypes.StoreProduct
     onSelectItem?: () => void
   } = $props()
-  const { image, origin } = $derived(vermouths[product.handle as Handle])
+  const { image, origin, variantImages } = $derived(vermouths[product.handle as Handle])
+  const defaultVariant = $derived(getDefaultVariant(product))
+  const eligibleVariantCount = $derived(getEligibleVariants(product).length)
+  const presentation = $derived(defaultVariant ? getVariantPresentation(defaultVariant) : null)
+  const storefrontImage = $derived(
+    defaultVariant
+      ? getVariantImage({
+          fallbackImage: image,
+          productTitle: product.title,
+          variant: defaultVariant,
+          variantCount: eligibleVariantCount,
+          variantImages,
+        })
+      : null,
+  )
   const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
   let isDiscountBadgeVisible = $state(false)
 
@@ -54,7 +74,9 @@
 <li class="grid-item aspect-[0.677/1] px-11 pb-7 pt-6 md:aspect-square md:py-6">
   <a
     class="flex h-full flex-col items-center"
-    href={resolve(`/sortiment/${product.handle}`)}
+    href={resolve(
+      `/sortiment/${product.handle}${defaultVariant?.sku ? `?variant=${encodeURIComponent(defaultVariant.sku)}` : ''}`,
+    )}
     onclick={handleSelectItem}
   >
     <h3 class="mb-2 whitespace-nowrap text-lg font-bold text-brand-blue md:mb-4">
@@ -62,16 +84,26 @@
     </h3>
     <p class="whitespace-nowrap text-xs">{origin}</p>
     <div class="relative flex flex-1 flex-col">
-      <img
-        alt={product.title}
-        class="my-auto w-auto md:max-h-44 lg:max-h-fit"
-        loading="lazy"
-        srcset={productSrcSet(image)}
-        src="{image}/w=145,h=290,fit=cover"
-        sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
-        width="290"
-        height="290"
-      />
+      {#if storefrontImage}
+        <img
+          alt={storefrontImage.altText}
+          class="my-auto w-auto md:max-h-44 lg:max-h-fit"
+          loading="lazy"
+          srcset={productSrcSet(storefrontImage.url)}
+          src="{storefrontImage.url}/w=145,h=290,fit=cover"
+          sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
+          width="290"
+          height="290"
+        />
+      {:else}
+        <div
+          aria-label="{product.title}. Billede mangler."
+          class="my-auto grid aspect-square w-full place-items-center border border-black bg-white/40 p-4 text-center text-xs font-bold"
+          role="img"
+        >
+          Billede mangler
+        </div>
+      {/if}
       <div class="overlay">
         <p class="btn whitespace-nowrap">KØB NU</p>
       </div>
@@ -93,6 +125,9 @@
     </div>
     <div class="min-h-11 text-center text-xs">
       <p>{product.subtitle}</p>
+      {#if presentation}
+        <p class="mt-1 font-bold">{presentation.packaging} · {presentation.size}</p>
+      {/if}
       {#if priceDisplay}
         <p class="mt-2 font-bold">
           {#if priceDisplay.isDiscounted}

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -26,17 +26,20 @@
   const { image, origin, variantImages } = $derived(vermouths[product.handle as Handle])
   const defaultVariant = $derived(getDefaultVariant(product))
   const eligibleVariantCount = $derived(getEligibleVariants(product).length)
-  const presentation = $derived(defaultVariant ? getVariantPresentation(defaultVariant) : null)
+  const presentation = $derived(getVariantPresentation(defaultVariant))
   const storefrontImage = $derived(
-    defaultVariant
-      ? getVariantImage({
-          fallbackImage: image,
-          productTitle: product.title,
-          variant: defaultVariant,
-          variantCount: eligibleVariantCount,
-          variantImages,
-        })
-      : null,
+    getVariantImage({
+      variantSku: defaultVariant.sku,
+      variantImages,
+    }) ??
+      (eligibleVariantCount === 1
+        ? {
+            altText: [product.title, presentation.packaging, presentation.size]
+              .filter(Boolean)
+              .join(' – '),
+            url: image,
+          }
+        : null),
   )
   const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
   let isDiscountBadgeVisible = $state(false)
@@ -74,9 +77,7 @@
 <li class="grid-item aspect-[0.677/1] px-11 pb-7 pt-6 md:aspect-square md:py-6">
   <a
     class="flex h-full flex-col items-center"
-    href={resolve(
-      `/sortiment/${product.handle}${defaultVariant?.sku ? `?variant=${encodeURIComponent(defaultVariant.sku)}` : ''}`,
-    )}
+    href={resolve(`/sortiment/${product.handle}?variant=${encodeURIComponent(defaultVariant.sku)}`)}
     onclick={handleSelectItem}
   >
     <h3 class="mb-2 whitespace-nowrap text-lg font-bold text-brand-blue md:mb-4">
@@ -125,9 +126,7 @@
     </div>
     <div class="min-h-11 text-center text-xs">
       <p>{product.subtitle}</p>
-      {#if presentation}
-        <p class="mt-1 font-bold">{presentation.packaging} · {presentation.size}</p>
-      {/if}
+      <p class="mt-1 font-bold">{presentation.packaging} · {presentation.size}</p>
       {#if priceDisplay}
         <p class="mt-2 font-bold">
           {#if priceDisplay.isDiscounted}

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -4,7 +4,6 @@
   import {
     getDefaultVariant,
     getEligibleVariants,
-    getPresentationImage,
     getVariantImage,
     getVariantImageAltText,
     getVariantLabel,
@@ -43,12 +42,7 @@
     }),
   )
   const storefrontImage = $derived(
-    getPresentationImage({
-      configuredImage,
-      fallbackAltText: imageAltText,
-      fallbackImage: image,
-      variantCount: eligibleVariantCount,
-    }),
+    configuredImage ?? (eligibleVariantCount === 1 ? { altText: imageAltText, url: image } : null),
   )
   const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
   let isDiscountBadgeVisible = $state(false)
@@ -94,20 +88,16 @@
     </h3>
     <p class="whitespace-nowrap text-xs">{origin}</p>
     <div class="relative flex flex-1 flex-col">
-      {#if storefrontImage}
-        <img
-          alt={storefrontImage.altText}
-          class="my-auto w-auto md:max-h-44 lg:max-h-fit"
-          loading="lazy"
-          srcset={productSrcSet(storefrontImage.url)}
-          src="{storefrontImage.url}/w=145,h=290,fit=cover"
-          sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
-          width="290"
-          height="290"
-        />
-      {:else}
-        <p class="my-auto text-center text-xs">{imageAltText}</p>
-      {/if}
+      <img
+        alt={storefrontImage?.altText ?? imageAltText}
+        class="my-auto w-auto md:max-h-44 lg:max-h-fit"
+        loading="lazy"
+        srcset={storefrontImage ? productSrcSet(storefrontImage.url) : undefined}
+        src={storefrontImage ? `${storefrontImage.url}/w=145,h=290,fit=cover` : undefined}
+        sizes="(max-width: 700px) 145px, (max-width: 1000px) 90px, 145px"
+        width="290"
+        height="290"
+      />
       <div class="overlay">
         <p class="btn whitespace-nowrap">KØB NU</p>
       </div>

--- a/src/lib/data/products.test.ts
+++ b/src/lib/data/products.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getVermouth, vermouths } from './products'
+
+describe('static product data', () => {
+  it('resolves a known product handle', () => {
+    expect(getVermouth('sardino-rojo')).toBe(vermouths['sardino-rojo'])
+  })
+
+  it.each([undefined, null, '', 'removed-product'])('rejects an unknown handle %s', (handle) => {
+    expect(getVermouth(handle)).toBeNull()
+  })
+})

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -26,7 +26,6 @@ interface Vermouth {
   origin: string
   recommendation: string
   scores: { body: number; fruityness: number; spiciness: number; sweetness: number }
-  sizeAndDegrees: string
   taste: string
   variantImages?: Record<string, StorefrontImage>
 }
@@ -57,10 +56,9 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/d9b17e95-18c8-4ded-a15b-182fb859c800',
-    origin: 'El Bierzo Leon, Nordvest Spanien 100 cl. / 15%',
+    origin: 'El Bierzo Leon, Nordvest Spanien / 15%',
     recommendation: 'Bør nydes afkølet og med en skive grape.',
     scores: { sweetness: 1, fruityness: 2, body: 2, spiciness: 3 },
-    sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Smagen er levende og koncentreret, hvor især kardemommen og de tørrede frugter er stærke, derudover er der nuancer af lakrids og vanilje. Duften er intens af søde krydderier blandet med tørret frugt som afsluttes med noter af kaffe. Dette gør sig gældende i en lang og vedvarende sødme med et perfekt bitter touch.',
     variantImages: {
@@ -99,10 +97,9 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/e5eb8eb6-444c-4217-6143-e652c2a9a100',
-    origin: 'El Bierzo Leon, Nordvest Spanien 100 cl. / 15%',
+    origin: 'El Bierzo Leon, Nordvest Spanien / 15%',
     recommendation: 'Bør nydes afkølet og med en skive grape.',
     scores: { sweetness: 2, fruityness: 2, body: 2, spiciness: 2 },
-    sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Forzudo Blanco giver en cremet fornemmelse med smagsnuancer af bittert æble, kandiseret citron, grønne urter og et strejf af tropiske frugter. Her fås en meget balanceret Vermouth med lige dele sødme og bitter.',
     variantImages: {
@@ -129,11 +126,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/d3977254-55e5-47f2-5a20-fbb544816800',
-    origin: 'El Bierzo Leon, Nordvest Spanien 2 x 100 cl. / 15%',
+    origin: 'El Bierzo Leon, Nordvest Spanien / 15%',
     recommendation:
       'Serveres afkølet med is og citrus. Rojo er oplagt som aperitif eller i Negroni og Manhattan, mens Blanco er frisk, aromatisk og perfekt med grape.',
     scores: { sweetness: 2, fruityness: 2, body: 2, spiciness: 3 },
-    sizeAndDegrees: '2 x 100 cl. / 15%',
     taste:
       'En pakke med Forzudo Rojo og Blanco fra León. Rojo er fyldig, krydret og bittersød, mens Blanco er lys, frisk og aromatisk med citrus, bitterhed og afrundet sødme.',
   },
@@ -158,11 +154,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/89f026f1-f193-45b4-bf8a-a9f9d89c3e00',
-    origin: 'Galicien, Nordvestkysten Spanien 75 cl / 15%',
+    origin: 'Galicien, Nordvestkysten Spanien / 15%',
     recommendation:
       'Serveres “on the rocks”, med en skive appelsin eller citron, nydes som aperitif med en lille snack ved hånden f.eks oliven, chips eller “fisk på dåse”',
     scores: { sweetness: 5, fruityness: 3, body: 5, spiciness: 4 },
-    sizeAndDegrees: '75 cl. / 15%',
     taste:
       'En rigtig god allround rød Vermouth som hverken er for sød, tør eller bitter - perfekt til enhver lejlighed. Noter af karamel, camille & kanel.',
     variantImages: {
@@ -189,11 +184,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/910a8496-b9ad-4685-f102-dea0a0e60d00',
-    origin: 'Galicien, Nordvestkysten Spanien 75 cl / 15%',
+    origin: 'Galicien, Nordvestkysten Spanien / 15%',
     recommendation:
       'Serveres ved 6-8 grader i glas med oliven og en skive appelsin. Nydes til forretter eller som aperitif med en lille snack ved hånden f.eks oliven, chips eller “fisk på dåse”.',
     scores: { sweetness: 5, fruityness: 3, body: 4, spiciness: 2 },
-    sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Halmgul i farven, stor harmoni og balance i smag, sødt og syrligt med friske og frugtige nuancer, meget aromatisk og med en lang smagsudholdenhed. Noter af blomster, planter og botaniske stoffer.',
     variantImages: {
@@ -220,11 +214,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/ad5d1750-dfa9-4aae-0bf3-b86e9b03b600',
-    origin: 'Galicien, Nordvestkysten Spanien 2 x 75 cl / 15%',
+    origin: 'Galicien, Nordvestkysten Spanien / 15%',
     recommendation:
       'Blanco fungerer perfekt som frisk aperitif på terrassen, mens Rojo er oplagt før maden eller i klassiske cocktails som Negroni og Manhattan.',
     scores: { sweetness: 5, fruityness: 3, body: 5, spiciness: 3 },
-    sizeAndDegrees: '2 x 75 cl. / 15%',
     taste: 'Blanco er lys, frisk og aromatisk, mens Rojo har mere fylde, krydderi og bitterhed.',
   },
   'carmeleta-orange': {
@@ -244,10 +237,9 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/682acd17-1447-46b6-af38-73a4e9864600',
-    origin: 'L’Alquería de la Comtessa Valencia 75cl / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia / 15%',
     recommendation: 'Serveres kold med is, og evt. et jordbær eller appelsin.',
     scores: { sweetness: 4, fruityness: 4, body: 5, spiciness: 1 },
-    sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Noter af citrusfrugter, kager, vanille karamel. Intens smag, afbalanceret med syrlighed. Let bitter citrus og krydret eftersmag. Carmeleta Orange har en frisk duft, balanceret med syrlighed samt søde og bitre undertoner.',
   },
@@ -264,11 +256,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/684162e5-028c-4ccd-0057-4f9c9a0f4900',
-    origin: 'L’Alquería de la Comtessa Valencia 75cl / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia / 15%',
     recommendation:
       'Serveres kold med is, alternativt i drinks med gin som en forfriskende supplement.',
     scores: { sweetness: 2, fruityness: 3, body: 2, spiciness: 3 },
-    sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Smagen er karakteriseret af elegante smage fra de traditionelle smage fra vermouth, men forfriskede med behagelige noter fra Ingefær og Saigon Kanel og afslutningsvis er vermouthen tilsmagt med fennikel og timian. Næsen er forfriskende og har klare noter af timian og fennikel.',
   },
@@ -285,11 +276,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/95ec3491-7126-4e90-a732-a8cf64eb5000',
-    origin: 'L’Alquería de la Comtessa Valencia 75cl / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia / 15%',
     recommendation:
       'Serveres bedst over is med appelsinskal – eller som fundament i klassiske cocktails som Negroni og Manhattan.',
     scores: { sweetness: 3, fruityness: 2, body: 3, spiciness: 5 },
-    sizeAndDegrees: '75 cl. / 15%',
     taste:
       'I næsen opleves Rosso aromatisk og balsamisk med mørke citrusnoter og krydret sødme. Smagen er fyldig og harmonisk med en flot balance mellem syre, bitterhed og sødme. Den lange finish efterlader noter af appelsin, krydderier og et elegant bittert bid.',
   },
@@ -306,11 +296,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/5f386ebe-dbbf-48d3-ec31-bbf48116eb00',
-    origin: 'L’Alquería de la Comtessa Valencia 3 x 75 cl / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia / 15%',
     recommendation:
       'Serveres afkølet med is og citrus. Orange er oplagt som frisk spritz, Rosso passer perfekt til Negroni og Manhattan, og Blanco er en lys aperitif til lange dage i solen.',
     scores: { sweetness: 3, fruityness: 3, body: 4, spiciness: 3 },
-    sizeAndDegrees: '3 x 75 cl. / 15%',
     taste:
       'En smagskasse med Carmeleta Orange, Rosso og Blanco. Tre moderne spanske vermouther fra Valencia med appelsin, middelhavsurter, frisk citrus, krydderi og balanceret bitterhed.',
   },
@@ -327,11 +316,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/03ff1c99-011f-4978-736f-7e56cc30be00',
-    origin: 'Spanien 3 x 75/100 cl. / 15%',
+    origin: 'Spanien / 15%',
     recommendation:
       'Serveres afkølet med is og appelsin. En oplagt rød vermouth-pakke til aperitif, snacks og klassiske cocktails som Negroni og Manhattan.',
     scores: { sweetness: 3, fruityness: 2, body: 4, spiciness: 4 },
-    sizeAndDegrees: '3 flasker / 15%',
     taste:
       'En blandet rød smagskasse med Sardino Rojo, Tabira og Forzudo Rojo. Tre fyldige spanske vermouther med krydderi, bitterhed, sødme og tydelig aperitif-karakter.',
   },
@@ -348,11 +336,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/68fe27a7-d137-4474-3de0-9441db70bd00',
-    origin: 'Spanien 3 x 75/100 cl. / 15%',
+    origin: 'Spanien / 15%',
     recommendation:
       'Serveres godt afkølet med is, citrus eller grøn oliven. En frisk hvid vermouth-pakke til aperitif, terrasseglas og lette cocktails.',
     scores: { sweetness: 3, fruityness: 3, body: 3, spiciness: 2 },
-    sizeAndDegrees: '3 flasker / 15%',
     taste:
       'En blandet hvid smagskasse med Sardino Blanco, Carmeleta Blanco og Forzudo Blanco. Tre friske spanske vermouther med citrus, urter, aromatisk sødme og let bitterhed.',
   },
@@ -369,11 +356,10 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/3a18bbad-4d4e-4ef4-3d55-797154b1fd00',
-    origin: 'Spanien 3 x 75/100 cl. / 15%',
+    origin: 'Spanien / 15%',
     recommendation:
       'Serveres afkølet med is og citrus. En oplagt gavepakke eller startpakke til dig, der vil smage rød, hvid og orange vermouth.',
     scores: { sweetness: 3, fruityness: 3, body: 4, spiciness: 3 },
-    sizeAndDegrees: '3 flasker / 15%',
     taste:
       'En blandet smagskasse med Tabira, Carmeleta Orange og Forzudo Blanco. Fra klassisk rød vermouth fra León til solmoden appelsin fra Valencia og frisk hvid vermouth fra El Bierzo.',
   },
@@ -390,10 +376,9 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/214da185-c1c9-4a72-f012-62d5bf8f0600',
-    origin: 'Leon Nordvest Spanien 100 cl. / 15%',
+    origin: 'Leon Nordvest Spanien / 15%',
     recommendation: 'Kold, med is og oliven som aperitif. Eller til en cocktail med rom, whisky',
     scores: { sweetness: 3, fruityness: 2, body: 4, spiciness: 4 },
-    sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Sødlig og blød i sin smag, dens friskhed og duft af appelsin gør den nem at drikke. Eftersmagen ligger langt tilbage i munden og arbejder sig ind, igennem sine mange aromaer og krydderier. Perfekt balance mellem det søde og det friske, som gør denne vermouth meget komplet. Bør nydes kold med is og appelsinskive, og med oliven som snack.',
   },

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -14,6 +14,11 @@ export type Handle =
   | 'mix-trio'
   | 'tabira'
 
+export interface StorefrontImage {
+  altText: string
+  url: string
+}
+
 interface Vermouth {
   extraImages: Array<{ altText: string; url: string }>
   image: string
@@ -23,6 +28,7 @@ interface Vermouth {
   scores: { body: number; fruityness: number; spiciness: number; sweetness: number }
   sizeAndDegrees: string
   taste: string
+  variantImages?: Record<string, StorefrontImage>
 }
 
 export const vermouths: Record<Handle, Vermouth> = {
@@ -57,6 +63,16 @@ export const vermouths: Record<Handle, Vermouth> = {
     sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Smagen er levende og koncentreret, hvor især kardemommen og de tørrede frugter er stærke, derudover er der nuancer af lakrids og vanilje. Duften er intens af søde krydderier blandet med tørret frugt som afsluttes med noter af kaffe. Dette gør sig gældende i en lang og vedvarende sødme med et perfekt bitter touch.',
+    variantImages: {
+      'forzudo-rojo-100cl-bottle': {
+        altText: 'Forzudo Rojo – Flaske, 100 cl',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/d9b17e95-18c8-4ded-a15b-182fb859c800',
+      },
+      'forzudo-rojo-3l-bag-in-box': {
+        altText: 'Forzudo Rojo – Bag-in-Box, 3 L',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/55adf4a7-8698-486d-8729-ef758858f000',
+      },
+    },
   },
   'forzudo-blanco': {
     brand: 'Forzudo',
@@ -89,6 +105,16 @@ export const vermouths: Record<Handle, Vermouth> = {
     sizeAndDegrees: '100 cl. / 15%',
     taste:
       'Forzudo Blanco giver en cremet fornemmelse med smagsnuancer af bittert æble, kandiseret citron, grønne urter og et strejf af tropiske frugter. Her fås en meget balanceret Vermouth med lige dele sødme og bitter.',
+    variantImages: {
+      'forzudo-blanco-100cl-bottle': {
+        altText: 'Forzudo Blanco – Flaske, 100 cl',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/e5eb8eb6-444c-4217-6143-e652c2a9a100',
+      },
+      'forzudo-blanco-3l-bag-in-box': {
+        altText: 'Forzudo Blanco – Bag-in-Box, 3 L',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/c147a7b3-0471-4273-b0ae-2d447731fc00',
+      },
+    },
   },
   'forzudo-combo': {
     brand: 'Forzudo',
@@ -139,6 +165,16 @@ export const vermouths: Record<Handle, Vermouth> = {
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'En rigtig god allround rød Vermouth som hverken er for sød, tør eller bitter - perfekt til enhver lejlighed. Noter af karamel, camille & kanel.',
+    variantImages: {
+      'sardino-rojo-75cl-bottle': {
+        altText: 'Sardino Rojo – Flaske, 75 cl',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/89f026f1-f193-45b4-bf8a-a9f9d89c3e00',
+      },
+      'sardino-rojo-5l-bag-in-box': {
+        altText: 'Sardino Rojo – Bag-in-Box, 5 L',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/82a37efe-7b03-4c8e-ca9b-65dd992ef400',
+      },
+    },
   },
   'sardino-blanco': {
     brand: 'Sardino',
@@ -160,6 +196,16 @@ export const vermouths: Record<Handle, Vermouth> = {
     sizeAndDegrees: '75 cl. / 15%',
     taste:
       'Halmgul i farven, stor harmoni og balance i smag, sødt og syrligt med friske og frugtige nuancer, meget aromatisk og med en lang smagsudholdenhed. Noter af blomster, planter og botaniske stoffer.',
+    variantImages: {
+      'sardino-blanco-75cl-bottle': {
+        altText: 'Sardino Blanco – Flaske, 75 cl',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/910a8496-b9ad-4685-f102-dea0a0e60d00',
+      },
+      'sardino-blanco-5l-bag-in-box': {
+        altText: 'Sardino Blanco – Bag-in-Box, 5 L',
+        url: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/63a8f10d-2dbd-44a9-4788-4da018b0bf00',
+      },
+    },
   },
   'sardino-combo': {
     brand: 'Sardino',

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -19,7 +19,7 @@ export interface StorefrontImage {
   url: string
 }
 
-interface Vermouth {
+export interface Vermouth {
   alcoholPercentage: string
   extraImages: Array<{ altText: string; url: string }>
   image: string
@@ -398,3 +398,9 @@ export const vermouths: Record<Handle, Vermouth> = {
       'Sødlig og blød i sin smag, dens friskhed og duft af appelsin gør den nem at drikke. Eftersmagen ligger langt tilbage i munden og arbejder sig ind, igennem sine mange aromaer og krydderier. Perfekt balance mellem det søde og det friske, som gør denne vermouth meget komplet. Bør nydes kold med is og appelsinskive, og med oliven som snack.',
   },
 } as const
+
+export function getVermouth(productHandle: string | null | undefined): Vermouth | null {
+  if (!productHandle || !Object.hasOwn(vermouths, productHandle)) return null
+
+  return vermouths[productHandle as Handle]
+}

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -15,7 +15,7 @@ export type Handle =
   | 'tabira'
 
 export interface StorefrontImage {
-  altText: string
+  altText?: string
   url: string
 }
 

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -20,6 +20,7 @@ export interface StorefrontImage {
 }
 
 interface Vermouth {
+  alcoholPercentage: string
   extraImages: Array<{ altText: string; url: string }>
   image: string
   brand: string
@@ -32,6 +33,7 @@ interface Vermouth {
 
 export const vermouths: Record<Handle, Vermouth> = {
   'forzudo-rojo': {
+    alcoholPercentage: '15%',
     brand: 'Forzudo',
     extraImages: [
       {
@@ -56,7 +58,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/d9b17e95-18c8-4ded-a15b-182fb859c800',
-    origin: 'El Bierzo Leon, Nordvest Spanien / 15%',
+    origin: 'El Bierzo Leon, Nordvest Spanien',
     recommendation: 'Bør nydes afkølet og med en skive grape.',
     scores: { sweetness: 1, fruityness: 2, body: 2, spiciness: 3 },
     taste:
@@ -73,6 +75,7 @@ export const vermouths: Record<Handle, Vermouth> = {
     },
   },
   'forzudo-blanco': {
+    alcoholPercentage: '15%',
     brand: 'Forzudo',
     extraImages: [
       {
@@ -97,7 +100,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/e5eb8eb6-444c-4217-6143-e652c2a9a100',
-    origin: 'El Bierzo Leon, Nordvest Spanien / 15%',
+    origin: 'El Bierzo Leon, Nordvest Spanien',
     recommendation: 'Bør nydes afkølet og med en skive grape.',
     scores: { sweetness: 2, fruityness: 2, body: 2, spiciness: 2 },
     taste:
@@ -114,6 +117,7 @@ export const vermouths: Record<Handle, Vermouth> = {
     },
   },
   'forzudo-combo': {
+    alcoholPercentage: '15%',
     brand: 'Forzudo',
     extraImages: [
       {
@@ -126,7 +130,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/d3977254-55e5-47f2-5a20-fbb544816800',
-    origin: 'El Bierzo Leon, Nordvest Spanien / 15%',
+    origin: 'El Bierzo Leon, Nordvest Spanien',
     recommendation:
       'Serveres afkølet med is og citrus. Rojo er oplagt som aperitif eller i Negroni og Manhattan, mens Blanco er frisk, aromatisk og perfekt med grape.',
     scores: { sweetness: 2, fruityness: 2, body: 2, spiciness: 3 },
@@ -134,6 +138,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'En pakke med Forzudo Rojo og Blanco fra León. Rojo er fyldig, krydret og bittersød, mens Blanco er lys, frisk og aromatisk med citrus, bitterhed og afrundet sødme.',
   },
   'sardino-rojo': {
+    alcoholPercentage: '15%',
     brand: 'Sardino',
     extraImages: [
       {
@@ -154,7 +159,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/89f026f1-f193-45b4-bf8a-a9f9d89c3e00',
-    origin: 'Galicien, Nordvestkysten Spanien / 15%',
+    origin: 'Galicien, Nordvestkysten Spanien',
     recommendation:
       'Serveres “on the rocks”, med en skive appelsin eller citron, nydes som aperitif med en lille snack ved hånden f.eks oliven, chips eller “fisk på dåse”',
     scores: { sweetness: 5, fruityness: 3, body: 5, spiciness: 4 },
@@ -172,6 +177,7 @@ export const vermouths: Record<Handle, Vermouth> = {
     },
   },
   'sardino-blanco': {
+    alcoholPercentage: '15%',
     brand: 'Sardino',
     extraImages: [
       {
@@ -184,7 +190,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/910a8496-b9ad-4685-f102-dea0a0e60d00',
-    origin: 'Galicien, Nordvestkysten Spanien / 15%',
+    origin: 'Galicien, Nordvestkysten Spanien',
     recommendation:
       'Serveres ved 6-8 grader i glas med oliven og en skive appelsin. Nydes til forretter eller som aperitif med en lille snack ved hånden f.eks oliven, chips eller “fisk på dåse”.',
     scores: { sweetness: 5, fruityness: 3, body: 4, spiciness: 2 },
@@ -202,6 +208,7 @@ export const vermouths: Record<Handle, Vermouth> = {
     },
   },
   'sardino-combo': {
+    alcoholPercentage: '15%',
     brand: 'Sardino',
     extraImages: [
       {
@@ -214,13 +221,14 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/ad5d1750-dfa9-4aae-0bf3-b86e9b03b600',
-    origin: 'Galicien, Nordvestkysten Spanien / 15%',
+    origin: 'Galicien, Nordvestkysten Spanien',
     recommendation:
       'Blanco fungerer perfekt som frisk aperitif på terrassen, mens Rojo er oplagt før maden eller i klassiske cocktails som Negroni og Manhattan.',
     scores: { sweetness: 5, fruityness: 3, body: 5, spiciness: 3 },
     taste: 'Blanco er lys, frisk og aromatisk, mens Rojo har mere fylde, krydderi og bitterhed.',
   },
   'carmeleta-orange': {
+    alcoholPercentage: '15%',
     brand: 'Carmeleta',
     extraImages: [
       {
@@ -237,13 +245,14 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/682acd17-1447-46b6-af38-73a4e9864600',
-    origin: 'L’Alquería de la Comtessa Valencia / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia',
     recommendation: 'Serveres kold med is, og evt. et jordbær eller appelsin.',
     scores: { sweetness: 4, fruityness: 4, body: 5, spiciness: 1 },
     taste:
       'Noter af citrusfrugter, kager, vanille karamel. Intens smag, afbalanceret med syrlighed. Let bitter citrus og krydret eftersmag. Carmeleta Orange har en frisk duft, balanceret med syrlighed samt søde og bitre undertoner.',
   },
   'carmeleta-blanco': {
+    alcoholPercentage: '15%',
     brand: 'Carmeleta',
     extraImages: [
       {
@@ -256,7 +265,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/684162e5-028c-4ccd-0057-4f9c9a0f4900',
-    origin: 'L’Alquería de la Comtessa Valencia / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia',
     recommendation:
       'Serveres kold med is, alternativt i drinks med gin som en forfriskende supplement.',
     scores: { sweetness: 2, fruityness: 3, body: 2, spiciness: 3 },
@@ -264,6 +273,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'Smagen er karakteriseret af elegante smage fra de traditionelle smage fra vermouth, men forfriskede med behagelige noter fra Ingefær og Saigon Kanel og afslutningsvis er vermouthen tilsmagt med fennikel og timian. Næsen er forfriskende og har klare noter af timian og fennikel.',
   },
   'carmeleta-rosso': {
+    alcoholPercentage: '15%',
     brand: 'Carmeleta',
     extraImages: [
       {
@@ -276,7 +286,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/95ec3491-7126-4e90-a732-a8cf64eb5000',
-    origin: 'L’Alquería de la Comtessa Valencia / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia',
     recommendation:
       'Serveres bedst over is med appelsinskal – eller som fundament i klassiske cocktails som Negroni og Manhattan.',
     scores: { sweetness: 3, fruityness: 2, body: 3, spiciness: 5 },
@@ -284,6 +294,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'I næsen opleves Rosso aromatisk og balsamisk med mørke citrusnoter og krydret sødme. Smagen er fyldig og harmonisk med en flot balance mellem syre, bitterhed og sødme. Den lange finish efterlader noter af appelsin, krydderier og et elegant bittert bid.',
   },
   'carmeleta-combo': {
+    alcoholPercentage: '15%',
     brand: 'Carmeleta',
     extraImages: [
       {
@@ -296,7 +307,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/5f386ebe-dbbf-48d3-ec31-bbf48116eb00',
-    origin: 'L’Alquería de la Comtessa Valencia / 15%',
+    origin: 'L’Alquería de la Comtessa Valencia',
     recommendation:
       'Serveres afkølet med is og citrus. Orange er oplagt som frisk spritz, Rosso passer perfekt til Negroni og Manhattan, og Blanco er en lys aperitif til lange dage i solen.',
     scores: { sweetness: 3, fruityness: 3, body: 4, spiciness: 3 },
@@ -304,6 +315,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'En smagskasse med Carmeleta Orange, Rosso og Blanco. Tre moderne spanske vermouther fra Valencia med appelsin, middelhavsurter, frisk citrus, krydderi og balanceret bitterhed.',
   },
   'mix-red': {
+    alcoholPercentage: '15%',
     brand: 'Vermouth.NU',
     extraImages: [
       {
@@ -316,7 +328,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/03ff1c99-011f-4978-736f-7e56cc30be00',
-    origin: 'Spanien / 15%',
+    origin: 'Spanien',
     recommendation:
       'Serveres afkølet med is og appelsin. En oplagt rød vermouth-pakke til aperitif, snacks og klassiske cocktails som Negroni og Manhattan.',
     scores: { sweetness: 3, fruityness: 2, body: 4, spiciness: 4 },
@@ -324,6 +336,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'En blandet rød smagskasse med Sardino Rojo, Tabira og Forzudo Rojo. Tre fyldige spanske vermouther med krydderi, bitterhed, sødme og tydelig aperitif-karakter.',
   },
   'mix-white': {
+    alcoholPercentage: '15%',
     brand: 'Vermouth.NU',
     extraImages: [
       {
@@ -336,7 +349,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/68fe27a7-d137-4474-3de0-9441db70bd00',
-    origin: 'Spanien / 15%',
+    origin: 'Spanien',
     recommendation:
       'Serveres godt afkølet med is, citrus eller grøn oliven. En frisk hvid vermouth-pakke til aperitif, terrasseglas og lette cocktails.',
     scores: { sweetness: 3, fruityness: 3, body: 3, spiciness: 2 },
@@ -344,6 +357,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'En blandet hvid smagskasse med Sardino Blanco, Carmeleta Blanco og Forzudo Blanco. Tre friske spanske vermouther med citrus, urter, aromatisk sødme og let bitterhed.',
   },
   'mix-trio': {
+    alcoholPercentage: '15%',
     brand: 'Vermouth.NU',
     extraImages: [
       {
@@ -356,7 +370,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/3a18bbad-4d4e-4ef4-3d55-797154b1fd00',
-    origin: 'Spanien / 15%',
+    origin: 'Spanien',
     recommendation:
       'Serveres afkølet med is og citrus. En oplagt gavepakke eller startpakke til dig, der vil smage rød, hvid og orange vermouth.',
     scores: { sweetness: 3, fruityness: 3, body: 4, spiciness: 3 },
@@ -364,6 +378,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       'En blandet smagskasse med Tabira, Carmeleta Orange og Forzudo Blanco. Fra klassisk rød vermouth fra León til solmoden appelsin fra Valencia og frisk hvid vermouth fra El Bierzo.',
   },
   tabira: {
+    alcoholPercentage: '15%',
     brand: 'Tabira',
     extraImages: [
       {
@@ -376,7 +391,7 @@ export const vermouths: Record<Handle, Vermouth> = {
       },
     ],
     image: 'https://imagedelivery.net/rOTc9tKCTQBc9ztkiBTX_w/214da185-c1c9-4a72-f012-62d5bf8f0600',
-    origin: 'Leon Nordvest Spanien / 15%',
+    origin: 'Leon Nordvest Spanien',
     recommendation: 'Kold, med is og oliven som aperitif. Eller til en cocktail med rom, whisky',
     scores: { sweetness: 3, fruityness: 2, body: 4, spiciness: 4 },
     taste:

--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -4,6 +4,7 @@ type GaListItem = {
   price?: string
   item_brand?: string
   item_category: string
+  item_variant?: string
   item_list_name?: string
   item_list_id?: string
   index?: number

--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -4,7 +4,7 @@ type GaListItem = {
   price?: string
   item_brand?: string
   item_category: string
-  item_variant?: string
+  item_variant: string
   item_list_name?: string
   item_list_id?: string
   index?: number

--- a/src/lib/helpers/prices.test.ts
+++ b/src/lib/helpers/prices.test.ts
@@ -47,7 +47,9 @@ describe('getProductPriceDisplay', () => {
     })
   })
 
-  it('returns null when Medusa did not calculate a price', () => {
-    expect(getProductPriceDisplay(productWithPrice(), 'dkk', 'da-DK')).toBeNull()
+  it('rejects a product without an eligible priced variant', () => {
+    expect(() => getProductPriceDisplay(productWithPrice(), 'dkk', 'da-DK')).toThrow(
+      'has no eligible variant',
+    )
   })
 })

--- a/src/lib/helpers/prices.test.ts
+++ b/src/lib/helpers/prices.test.ts
@@ -15,6 +15,10 @@ function productWithPrice(
   return {
     variants: [
       {
+        id: 'variant-test',
+        sku: 'test-75cl-bottle',
+        title: 'Flaske',
+        variant_rank: 0,
         calculated_price: {
           calculated_amount: calculatedAmount,
           original_amount: originalAmount,

--- a/src/lib/helpers/prices.ts
+++ b/src/lib/helpers/prices.ts
@@ -1,22 +1,9 @@
-import { formatPrice } from '$lib/helpers/numbers'
-import { getDefaultVariant, type ProductVariant } from '$lib/helpers/product-variants'
+import {
+  getDefaultVariant,
+  getVariantPriceDisplay,
+  type ProductPriceDisplay,
+} from '$lib/helpers/product-variants'
 import type { HttpTypes } from '@medusajs/types'
-
-type CalculatedPrice = NonNullable<ProductVariant['calculated_price']> & {
-  calculated_amount?: number | null
-  original_amount?: number | null
-}
-
-export type ProductPriceDisplay = {
-  current: string
-  original?: string
-  savingsPercent?: number
-  isDiscounted: boolean
-}
-
-function toAmount(amount: number | null | undefined): number | null {
-  return typeof amount === 'number' ? amount : null
-}
 
 export function getProductPriceDisplay(
   product: HttpTypes.StoreProduct,
@@ -24,30 +11,4 @@ export function getProductPriceDisplay(
   locale: string,
 ): ProductPriceDisplay | null {
   return getVariantPriceDisplay(getDefaultVariant(product), currencyCode, locale)
-}
-
-export function getVariantPriceDisplay(
-  variant: ProductVariant,
-  currencyCode: string,
-  locale: string,
-): ProductPriceDisplay | null {
-  const price = variant.calculated_price as CalculatedPrice | undefined
-  const calculatedAmount = toAmount(price?.calculated_amount)
-
-  if (calculatedAmount === null) {
-    return null
-  }
-
-  const originalAmount = toAmount(price?.original_amount)
-  const isDiscounted = originalAmount !== null && originalAmount > calculatedAmount
-  const savingsPercent = isDiscounted
-    ? Math.round(((originalAmount - calculatedAmount) / originalAmount) * 100)
-    : undefined
-
-  return {
-    current: formatPrice(calculatedAmount, currencyCode, locale),
-    original: isDiscounted ? formatPrice(originalAmount, currencyCode, locale) : undefined,
-    savingsPercent,
-    isDiscounted,
-  }
 }

--- a/src/lib/helpers/prices.ts
+++ b/src/lib/helpers/prices.ts
@@ -1,7 +1,7 @@
 import { formatPrice } from '$lib/helpers/numbers'
+import { getDefaultVariant, type ProductVariant } from '$lib/helpers/product-variants'
 import type { HttpTypes } from '@medusajs/types'
 
-type ProductVariant = NonNullable<HttpTypes.StoreProduct['variants']>[number]
 type CalculatedPrice = NonNullable<ProductVariant['calculated_price']> & {
   calculated_amount?: number | null
   original_amount?: number | null
@@ -23,7 +23,16 @@ export function getProductPriceDisplay(
   currencyCode: string,
   locale: string,
 ): ProductPriceDisplay | null {
-  const price = product.variants?.[0]?.calculated_price as CalculatedPrice | undefined
+  const variant = getDefaultVariant(product)
+  return variant ? getVariantPriceDisplay(variant, currencyCode, locale) : null
+}
+
+export function getVariantPriceDisplay(
+  variant: ProductVariant,
+  currencyCode: string,
+  locale: string,
+): ProductPriceDisplay | null {
+  const price = variant.calculated_price as CalculatedPrice | undefined
   const calculatedAmount = toAmount(price?.calculated_amount)
 
   if (calculatedAmount === null) {

--- a/src/lib/helpers/prices.ts
+++ b/src/lib/helpers/prices.ts
@@ -23,8 +23,7 @@ export function getProductPriceDisplay(
   currencyCode: string,
   locale: string,
 ): ProductPriceDisplay | null {
-  const variant = getDefaultVariant(product)
-  return variant ? getVariantPriceDisplay(variant, currencyCode, locale) : null
+  return getVariantPriceDisplay(getDefaultVariant(product), currencyCode, locale)
 }
 
 export function getVariantPriceDisplay(

--- a/src/lib/helpers/product-variants.test.ts
+++ b/src/lib/helpers/product-variants.test.ts
@@ -60,6 +60,10 @@ describe('product variant selection', () => {
     expect(getDefaultVariant(product([box, bottle]))).toBe(bottle)
   })
 
+  it('rejects a product without an eligible variant', () => {
+    expect(() => getDefaultVariant(product([]))).toThrow('has no eligible variant')
+  })
+
   it('excludes a variant without an active-region calculated price', () => {
     const unavailable = {
       ...box,
@@ -91,10 +95,7 @@ describe('variant storefront images', () => {
   it('resolves the selected variant image by SKU', () => {
     expect(
       getVariantImage({
-        fallbackImage: 'legacy',
-        productTitle: 'Wine',
-        variant: box,
-        variantCount: 2,
+        variantSku: box.sku!,
         variantImages: {
           [box.sku!]: { altText: 'Wine box', url: 'box-image' },
         },
@@ -105,25 +106,19 @@ describe('variant storefront images', () => {
   it('does not show another presentation image for a multi-variant product', () => {
     expect(
       getVariantImage({
-        fallbackImage: 'legacy-bottle',
-        productTitle: 'Wine',
-        variant: box,
-        variantCount: 2,
+        variantSku: box.sku!,
       }),
     ).toBeNull()
   })
 
-  it('keeps the legacy image fallback for a single-variant product', () => {
+  it('does not resolve a missing SKU mapping', () => {
     expect(
       getVariantImage({
-        fallbackImage: 'legacy-bottle',
-        productTitle: 'Wine',
-        variant: bottle,
-        variantCount: 1,
+        variantSku: 'other-75cl-bottle',
+        variantImages: {
+          [bottle.sku!]: { altText: 'Wine bottle', url: 'bottle-image' },
+        },
       }),
-    ).toEqual({
-      altText: 'Wine – Flaske – 75 cl',
-      url: 'legacy-bottle',
-    })
+    ).toBeNull()
   })
 })

--- a/src/lib/helpers/product-variants.test.ts
+++ b/src/lib/helpers/product-variants.test.ts
@@ -1,0 +1,129 @@
+import {
+  getDefaultVariant,
+  getEligibleVariants,
+  getLineItemVariantLabel,
+  getVariantBySku,
+  getVariantImage,
+  getVariantLabel,
+} from '$lib/helpers/product-variants'
+import type { HttpTypes } from '@medusajs/types'
+import { describe, expect, it } from 'vitest'
+
+function variant({
+  id,
+  price = 100,
+  rank,
+  size,
+  sku,
+  title,
+}: {
+  id: string
+  price?: number
+  rank: number
+  size: string
+  sku: string
+  title: string
+}) {
+  return {
+    id,
+    sku,
+    title,
+    variant_rank: rank,
+    calculated_price: { calculated_amount: price },
+    options: [{ value: size, option: { title: 'Size' } }],
+  } as HttpTypes.StoreProductVariant
+}
+
+function product(variants: HttpTypes.StoreProductVariant[]) {
+  return { variants } as HttpTypes.StoreProduct
+}
+
+const bottle = variant({
+  id: 'bottle',
+  rank: 0,
+  size: '75 cl',
+  sku: 'wine-75cl-bottle',
+  title: 'Flaske',
+})
+const box = variant({
+  id: 'box',
+  price: 800,
+  rank: 1,
+  size: '5 L',
+  sku: 'wine-5l-bag-in-box',
+  title: 'Bag-in-Box',
+})
+
+describe('product variant selection', () => {
+  it('orders eligible variants by rank rather than response order', () => {
+    expect(getEligibleVariants(product([box, bottle]))).toEqual([bottle, box])
+    expect(getDefaultVariant(product([box, bottle]))).toBe(bottle)
+  })
+
+  it('excludes a variant without an active-region calculated price', () => {
+    const unavailable = {
+      ...box,
+      calculated_price: undefined,
+    } as HttpTypes.StoreProductVariant
+
+    expect(getEligibleVariants(product([unavailable, bottle]))).toEqual([bottle])
+  })
+
+  it('restores an eligible variant from its stable SKU', () => {
+    const eligible = getEligibleVariants(product([box, bottle]))
+
+    expect(getVariantBySku(eligible, box.sku)).toBe(box)
+    expect(getVariantBySku(eligible, 'legacy-variant-id')).toBeNull()
+  })
+
+  it('combines the translated packaging title and Size option', () => {
+    expect(getVariantLabel(box)).toBe('Bag-in-Box — 5 L')
+    expect(
+      getLineItemVariantLabel({
+        optionValues: { Size: '5 L' },
+        title: 'Bag-in-Box',
+      }),
+    ).toBe('Bag-in-Box — 5 L')
+  })
+})
+
+describe('variant storefront images', () => {
+  it('resolves the selected variant image by SKU', () => {
+    expect(
+      getVariantImage({
+        fallbackImage: 'legacy',
+        productTitle: 'Wine',
+        variant: box,
+        variantCount: 2,
+        variantImages: {
+          [box.sku!]: { altText: 'Wine box', url: 'box-image' },
+        },
+      }),
+    ).toEqual({ altText: 'Wine box', url: 'box-image' })
+  })
+
+  it('does not show another presentation image for a multi-variant product', () => {
+    expect(
+      getVariantImage({
+        fallbackImage: 'legacy-bottle',
+        productTitle: 'Wine',
+        variant: box,
+        variantCount: 2,
+      }),
+    ).toBeNull()
+  })
+
+  it('keeps the legacy image fallback for a single-variant product', () => {
+    expect(
+      getVariantImage({
+        fallbackImage: 'legacy-bottle',
+        productTitle: 'Wine',
+        variant: bottle,
+        variantCount: 1,
+      }),
+    ).toEqual({
+      altText: 'Wine – Flaske – 75 cl',
+      url: 'legacy-bottle',
+    })
+  })
+})

--- a/src/lib/helpers/product-variants.test.ts
+++ b/src/lib/helpers/product-variants.test.ts
@@ -2,7 +2,6 @@ import {
   getDefaultVariant,
   getEligibleVariants,
   getLineItemVariantLabel,
-  getPresentationImage,
   getVariantBySku,
   getVariantImage,
   getVariantImageAltText,
@@ -159,28 +158,6 @@ describe('variant storefront images', () => {
         },
       }),
     ).toEqual({ altText: 'Wine – Bag-in-Box, 5 L', url: 'box-image' })
-  })
-
-  it('uses the legacy product image only for a single-variant product', () => {
-    expect(
-      getPresentationImage({
-        configuredImage: null,
-        fallbackAltText: 'Wine – Flaske, 75 cl',
-        fallbackImage: 'legacy-image',
-        variantCount: 1,
-      }),
-    ).toEqual({ altText: 'Wine – Flaske, 75 cl', url: 'legacy-image' })
-  })
-
-  it('preserves a missing image for an unmapped multi-variant presentation', () => {
-    expect(
-      getPresentationImage({
-        configuredImage: null,
-        fallbackAltText: 'Wine – Bag-in-Box, 5 L',
-        fallbackImage: 'bottle-image',
-        variantCount: 2,
-      }),
-    ).toBeNull()
   })
 })
 

--- a/src/lib/helpers/product-variants.test.ts
+++ b/src/lib/helpers/product-variants.test.ts
@@ -2,6 +2,7 @@ import {
   getDefaultVariant,
   getEligibleVariants,
   getLineItemVariantLabel,
+  getPresentationImage,
   getVariantBySku,
   getVariantImage,
   getVariantImageAltText,
@@ -158,6 +159,28 @@ describe('variant storefront images', () => {
         },
       }),
     ).toEqual({ altText: 'Wine – Bag-in-Box, 5 L', url: 'box-image' })
+  })
+
+  it('uses the legacy product image only for a single-variant product', () => {
+    expect(
+      getPresentationImage({
+        configuredImage: null,
+        fallbackAltText: 'Wine – Flaske, 75 cl',
+        fallbackImage: 'legacy-image',
+        variantCount: 1,
+      }),
+    ).toEqual({ altText: 'Wine – Flaske, 75 cl', url: 'legacy-image' })
+  })
+
+  it('preserves a missing image for an unmapped multi-variant presentation', () => {
+    expect(
+      getPresentationImage({
+        configuredImage: null,
+        fallbackAltText: 'Wine – Bag-in-Box, 5 L',
+        fallbackImage: 'bottle-image',
+        variantCount: 2,
+      }),
+    ).toBeNull()
   })
 })
 

--- a/src/lib/helpers/product-variants.test.ts
+++ b/src/lib/helpers/product-variants.test.ts
@@ -4,7 +4,9 @@ import {
   getLineItemVariantLabel,
   getVariantBySku,
   getVariantImage,
+  getVariantImageAltText,
   getVariantLabel,
+  getVariantPriceDisplay,
 } from '$lib/helpers/product-variants'
 import type { HttpTypes } from '@medusajs/types'
 import { describe, expect, it } from 'vitest'
@@ -64,6 +66,15 @@ describe('product variant selection', () => {
     expect(() => getDefaultVariant(product([]))).toThrow('has no eligible variant')
   })
 
+  it('rejects duplicate eligible SKUs and ranks', () => {
+    expect(() => getEligibleVariants(product([bottle, { ...box, sku: bottle.sku }]))).toThrow(
+      'duplicate eligible variant SKU',
+    )
+    expect(() =>
+      getEligibleVariants(product([bottle, { ...box, variant_rank: bottle.variant_rank }])),
+    ).toThrow('duplicate eligible variant rank')
+  })
+
   it('excludes a variant without an active-region calculated price', () => {
     const unavailable = {
       ...box,
@@ -84,6 +95,16 @@ describe('product variant selection', () => {
     expect(getVariantLabel(box)).toBe('Bag-in-Box — 5 L')
     expect(
       getLineItemVariantLabel({
+        product: product([bottle, box]),
+        sku: box.sku,
+        title: 'Bag-in-Box',
+      }),
+    ).toBe('Bag-in-Box — 5 L')
+  })
+
+  it('falls back to line-item option values when the catalog variant is unavailable', () => {
+    expect(
+      getLineItemVariantLabel({
         optionValues: { Size: '5 L' },
         title: 'Bag-in-Box',
       }),
@@ -95,6 +116,7 @@ describe('variant storefront images', () => {
   it('resolves the selected variant image by SKU', () => {
     expect(
       getVariantImage({
+        fallbackAltText: 'Wine – Bag-in-Box, 5 L',
         variantSku: box.sku!,
         variantImages: {
           [box.sku!]: { altText: 'Wine box', url: 'box-image' },
@@ -106,6 +128,7 @@ describe('variant storefront images', () => {
   it('does not show another presentation image for a multi-variant product', () => {
     expect(
       getVariantImage({
+        fallbackAltText: 'Wine – Bag-in-Box, 5 L',
         variantSku: box.sku!,
       }),
     ).toBeNull()
@@ -114,11 +137,35 @@ describe('variant storefront images', () => {
   it('does not resolve a missing SKU mapping', () => {
     expect(
       getVariantImage({
+        fallbackAltText: 'Wine – Bag-in-Box, 5 L',
         variantSku: 'other-75cl-bottle',
         variantImages: {
           [bottle.sku!]: { altText: 'Wine bottle', url: 'bottle-image' },
         },
       }),
     ).toBeNull()
+  })
+
+  it('composes alt text when the configured image has none', () => {
+    const fallbackAltText = getVariantImageAltText('Wine', getVariantLabel(box))
+
+    expect(
+      getVariantImage({
+        fallbackAltText,
+        variantSku: box.sku!,
+        variantImages: {
+          [box.sku!]: { url: 'box-image' },
+        },
+      }),
+    ).toEqual({ altText: 'Wine – Bag-in-Box, 5 L', url: 'box-image' })
+  })
+})
+
+describe('variant prices', () => {
+  it('formats the selected variant price', () => {
+    expect(getVariantPriceDisplay(box, 'dkk', 'da-DK')).toMatchObject({
+      current: expect.stringMatching(/800[,.]00/),
+      isDiscounted: false,
+    })
   })
 })

--- a/src/lib/helpers/product-variants.ts
+++ b/src/lib/helpers/product-variants.ts
@@ -2,6 +2,10 @@ import type { StorefrontImage } from '$lib/data/products'
 import type { HttpTypes } from '@medusajs/types'
 
 export type ProductVariant = NonNullable<HttpTypes.StoreProduct['variants']>[number]
+export type EligibleProductVariant = ProductVariant & {
+  sku: string
+  variant_rank: number
+}
 
 export type VariantPresentation = {
   packaging: string
@@ -12,24 +16,34 @@ function hasCalculatedPrice(variant: ProductVariant) {
   return typeof variant.calculated_price?.calculated_amount === 'number'
 }
 
-function hasStableIdentity(variant: ProductVariant) {
-  return Boolean(variant.sku?.trim()) && Number.isInteger(variant.variant_rank)
+function isEligibleVariant(variant: ProductVariant): variant is EligibleProductVariant {
+  return (
+    hasCalculatedPrice(variant) &&
+    typeof variant.sku === 'string' &&
+    Boolean(variant.sku.trim()) &&
+    Number.isInteger(variant.variant_rank)
+  )
 }
 
-export function getEligibleVariants(product: HttpTypes.StoreProduct): ProductVariant[] {
+export function getEligibleVariants(product: HttpTypes.StoreProduct): EligibleProductVariant[] {
   return (product.variants ?? [])
-    .filter((variant) => hasCalculatedPrice(variant) && hasStableIdentity(variant))
-    .toSorted((left, right) => left.variant_rank! - right.variant_rank!)
+    .filter(isEligibleVariant)
+    .toSorted((left, right) => left.variant_rank - right.variant_rank)
 }
 
-export function getDefaultVariant(product: HttpTypes.StoreProduct): ProductVariant | null {
-  return getEligibleVariants(product)[0] ?? null
+export function getDefaultVariant(product: HttpTypes.StoreProduct): EligibleProductVariant {
+  const defaultVariant = getEligibleVariants(product)[0]
+  if (!defaultVariant) {
+    throw new Error(`Product ${product.handle ?? product.id ?? 'unknown'} has no eligible variant`)
+  }
+
+  return defaultVariant
 }
 
 export function getVariantBySku(
-  variants: ProductVariant[],
+  variants: EligibleProductVariant[],
   requestedSku: string | null,
-): ProductVariant | null {
+): EligibleProductVariant | null {
   if (!requestedSku) return null
   return variants.find(({ sku }) => sku === requestedSku) ?? null
 }
@@ -69,25 +83,11 @@ export function getLineItemVariantLabel({
 }
 
 export function getVariantImage({
-  fallbackImage,
-  productTitle,
-  variant,
-  variantCount,
+  variantSku,
   variantImages,
 }: {
-  fallbackImage: string
-  productTitle: string
-  variant: ProductVariant
-  variantCount: number
+  variantSku: string
   variantImages?: Record<string, StorefrontImage>
 }): StorefrontImage | null {
-  const configuredImage = variant.sku ? variantImages?.[variant.sku] : undefined
-  if (configuredImage) return configuredImage
-  if (variantCount !== 1) return null
-
-  const { packaging, size } = getVariantPresentation(variant)
-  return {
-    altText: [productTitle, packaging, size].filter(Boolean).join(' – '),
-    url: fallbackImage,
-  }
+  return variantImages?.[variantSku] ?? null
 }

--- a/src/lib/helpers/product-variants.ts
+++ b/src/lib/helpers/product-variants.ts
@@ -146,26 +146,6 @@ export function getVariantImage({
   }
 }
 
-export function getPresentationImage({
-  configuredImage,
-  fallbackAltText,
-  fallbackImage,
-  variantCount,
-}: {
-  configuredImage: ResolvedStorefrontImage | null
-  fallbackAltText: string
-  fallbackImage: string
-  variantCount: number
-}): ResolvedStorefrontImage | null {
-  if (configuredImage) return configuredImage
-  if (variantCount !== 1) return null
-
-  return {
-    altText: fallbackAltText,
-    url: fallbackImage,
-  }
-}
-
 function toAmount(amount: number | null | undefined): number | null {
   return typeof amount === 'number' ? amount : null
 }

--- a/src/lib/helpers/product-variants.ts
+++ b/src/lib/helpers/product-variants.ts
@@ -146,6 +146,26 @@ export function getVariantImage({
   }
 }
 
+export function getPresentationImage({
+  configuredImage,
+  fallbackAltText,
+  fallbackImage,
+  variantCount,
+}: {
+  configuredImage: ResolvedStorefrontImage | null
+  fallbackAltText: string
+  fallbackImage: string
+  variantCount: number
+}): ResolvedStorefrontImage | null {
+  if (configuredImage) return configuredImage
+  if (variantCount !== 1) return null
+
+  return {
+    altText: fallbackAltText,
+    url: fallbackImage,
+  }
+}
+
 function toAmount(amount: number | null | undefined): number | null {
   return typeof amount === 'number' ? amount : null
 }

--- a/src/lib/helpers/product-variants.ts
+++ b/src/lib/helpers/product-variants.ts
@@ -1,4 +1,5 @@
 import type { StorefrontImage } from '$lib/data/products'
+import { formatPrice } from '$lib/helpers/numbers'
 import type { HttpTypes } from '@medusajs/types'
 
 export type ProductVariant = NonNullable<HttpTypes.StoreProduct['variants']>[number]
@@ -10,6 +11,22 @@ export type EligibleProductVariant = ProductVariant & {
 export type VariantPresentation = {
   packaging: string
   size: string
+}
+
+type CalculatedPrice = NonNullable<ProductVariant['calculated_price']> & {
+  calculated_amount?: number | null
+  original_amount?: number | null
+}
+
+export type ProductPriceDisplay = {
+  current: string
+  original?: string
+  savingsPercent?: number
+  isDiscounted: boolean
+}
+
+export type ResolvedStorefrontImage = StorefrontImage & {
+  altText: string
 }
 
 function hasCalculatedPrice(variant: ProductVariant) {
@@ -26,9 +43,27 @@ function isEligibleVariant(variant: ProductVariant): variant is EligibleProductV
 }
 
 export function getEligibleVariants(product: HttpTypes.StoreProduct): EligibleProductVariant[] {
-  return (product.variants ?? [])
-    .filter(isEligibleVariant)
-    .toSorted((left, right) => left.variant_rank - right.variant_rank)
+  const eligibleVariants = (product.variants ?? []).filter(isEligibleVariant)
+  const skus = new Set<string>()
+  const ranks = new Set<number>()
+
+  for (const variant of eligibleVariants) {
+    if (skus.has(variant.sku)) {
+      throw new Error(
+        `Product ${product.handle ?? product.id ?? 'unknown'} has duplicate eligible variant SKU ${variant.sku}`,
+      )
+    }
+    if (ranks.has(variant.variant_rank)) {
+      throw new Error(
+        `Product ${product.handle ?? product.id ?? 'unknown'} has duplicate eligible variant rank ${variant.variant_rank}`,
+      )
+    }
+
+    skus.add(variant.sku)
+    ranks.add(variant.variant_rank)
+  }
+
+  return eligibleVariants.toSorted((left, right) => left.variant_rank - right.variant_rank)
 }
 
 export function getDefaultVariant(product: HttpTypes.StoreProduct): EligibleProductVariant {
@@ -65,13 +100,24 @@ export function getVariantLabel(variant: ProductVariant) {
   return size ? `${packaging} — ${size}` : packaging
 }
 
+export function getVariantImageAltText(productTitle: string, variantLabel: string) {
+  return `${productTitle} – ${variantLabel.replace(' — ', ', ')}`
+}
+
 export function getLineItemVariantLabel({
   optionValues,
+  product,
+  sku,
   title,
 }: {
   optionValues?: Record<string, unknown> | null
+  product?: HttpTypes.StoreProduct | null
+  sku?: string | null
   title?: string | null
 }) {
+  const catalogVariant = product && sku ? getVariantBySku(getEligibleVariants(product), sku) : null
+  if (catalogVariant) return getVariantLabel(catalogVariant)
+
   const sizeEntry = Object.entries(optionValues ?? {}).find(
     ([optionTitle, value]) => optionTitle.toLowerCase() === 'size' && typeof value === 'string',
   )
@@ -83,11 +129,49 @@ export function getLineItemVariantLabel({
 }
 
 export function getVariantImage({
+  fallbackAltText,
   variantSku,
   variantImages,
 }: {
+  fallbackAltText: string
   variantSku: string
   variantImages?: Record<string, StorefrontImage>
-}): StorefrontImage | null {
-  return variantImages?.[variantSku] ?? null
+}): ResolvedStorefrontImage | null {
+  const image = variantImages?.[variantSku]
+  if (!image) return null
+
+  return {
+    ...image,
+    altText: image.altText?.trim() || fallbackAltText,
+  }
+}
+
+function toAmount(amount: number | null | undefined): number | null {
+  return typeof amount === 'number' ? amount : null
+}
+
+export function getVariantPriceDisplay(
+  variant: ProductVariant,
+  currencyCode: string,
+  locale: string,
+): ProductPriceDisplay | null {
+  const price = variant.calculated_price as CalculatedPrice | undefined
+  const calculatedAmount = toAmount(price?.calculated_amount)
+
+  if (calculatedAmount === null) {
+    return null
+  }
+
+  const originalAmount = toAmount(price?.original_amount)
+  const isDiscounted = originalAmount !== null && originalAmount > calculatedAmount
+  const savingsPercent = isDiscounted
+    ? Math.round(((originalAmount - calculatedAmount) / originalAmount) * 100)
+    : undefined
+
+  return {
+    current: formatPrice(calculatedAmount, currencyCode, locale),
+    original: isDiscounted ? formatPrice(originalAmount, currencyCode, locale) : undefined,
+    savingsPercent,
+    isDiscounted,
+  }
 }

--- a/src/lib/helpers/product-variants.ts
+++ b/src/lib/helpers/product-variants.ts
@@ -1,0 +1,93 @@
+import type { StorefrontImage } from '$lib/data/products'
+import type { HttpTypes } from '@medusajs/types'
+
+export type ProductVariant = NonNullable<HttpTypes.StoreProduct['variants']>[number]
+
+export type VariantPresentation = {
+  packaging: string
+  size: string
+}
+
+function hasCalculatedPrice(variant: ProductVariant) {
+  return typeof variant.calculated_price?.calculated_amount === 'number'
+}
+
+function hasStableIdentity(variant: ProductVariant) {
+  return Boolean(variant.sku?.trim()) && Number.isInteger(variant.variant_rank)
+}
+
+export function getEligibleVariants(product: HttpTypes.StoreProduct): ProductVariant[] {
+  return (product.variants ?? [])
+    .filter((variant) => hasCalculatedPrice(variant) && hasStableIdentity(variant))
+    .toSorted((left, right) => left.variant_rank! - right.variant_rank!)
+}
+
+export function getDefaultVariant(product: HttpTypes.StoreProduct): ProductVariant | null {
+  return getEligibleVariants(product)[0] ?? null
+}
+
+export function getVariantBySku(
+  variants: ProductVariant[],
+  requestedSku: string | null,
+): ProductVariant | null {
+  if (!requestedSku) return null
+  return variants.find(({ sku }) => sku === requestedSku) ?? null
+}
+
+export function getVariantPresentation(variant: ProductVariant): VariantPresentation {
+  const size =
+    variant.options?.find(({ option }) => option?.title.toLowerCase() === 'size')?.value ??
+    variant.options?.[0]?.value ??
+    ''
+
+  return {
+    packaging: variant.title?.trim() || 'Variant',
+    size,
+  }
+}
+
+export function getVariantLabel(variant: ProductVariant) {
+  const { packaging, size } = getVariantPresentation(variant)
+  return size ? `${packaging} — ${size}` : packaging
+}
+
+export function getLineItemVariantLabel({
+  optionValues,
+  title,
+}: {
+  optionValues?: Record<string, unknown> | null
+  title?: string | null
+}) {
+  const sizeEntry = Object.entries(optionValues ?? {}).find(
+    ([optionTitle, value]) => optionTitle.toLowerCase() === 'size' && typeof value === 'string',
+  )
+  const firstValue = Object.values(optionValues ?? {}).find((value) => typeof value === 'string')
+  const size = (sizeEntry?.[1] ?? firstValue) as string | undefined
+  const packaging = title?.trim() || 'Variant'
+
+  return size ? `${packaging} — ${size}` : packaging
+}
+
+export function getVariantImage({
+  fallbackImage,
+  productTitle,
+  variant,
+  variantCount,
+  variantImages,
+}: {
+  fallbackImage: string
+  productTitle: string
+  variant: ProductVariant
+  variantCount: number
+  variantImages?: Record<string, StorefrontImage>
+}): StorefrontImage | null {
+  const configuredImage = variant.sku ? variantImages?.[variant.sku] : undefined
+  if (configuredImage) return configuredImage
+  if (variantCount !== 1) return null
+
+  const { packaging, size } = getVariantPresentation(variant)
+  return {
+    altText: [productTitle, packaging, size].filter(Boolean).join(' – '),
+    url: fallbackImage,
+  }
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,7 +1,7 @@
 import type { LayoutServerLoad } from './$types'
 import { sdk } from '$lib/medusa'
 import { arePurchasesPaused } from '$lib/server/purchase-availability'
-import { HttpTypes } from '@medusajs/types'
+import type { HttpTypes } from '@medusajs/types'
 
 type CategoryHandle = 'red' | 'white' | 'other' | 'packs'
 
@@ -19,7 +19,7 @@ export const load: LayoutServerLoad = async ({ cookies, depends, locals }) => {
   const [{ id: regionId }] = regions
 
   const { products } = await sdk.store.product.list({
-    fields: '*categories,*variants.calculated_price',
+    fields: '*categories,*options,*variants,*variants.options,*variants.calculated_price',
     region_id: regionId,
   })
 

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -14,6 +14,7 @@
     type GaListItem,
   } from '$lib/helpers/analytics'
   import { thumbnailSrcSet } from '$lib/helpers/images'
+  import { getEligibleVariants, getLineItemVariantLabel } from '$lib/helpers/product-variants'
   import Checkbox from '$lib/components/form-controls/checkbox.svelte'
   import Form from '$lib/components/form-controls/form.svelte'
   import Input from '$lib/components/form-controls/input.svelte'
@@ -67,6 +68,7 @@
     cartItemId: string
     productHandle?: string
     productTitle?: string
+    itemVariant?: string
     unitPrice: number
     previousQuantity: number
     productId?: string
@@ -157,6 +159,7 @@
       item_category: categoryHandle
         ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
         : GA_MISSING.itemCategory,
+      item_variant: context.itemVariant,
       quantity,
     }
   }
@@ -171,12 +174,34 @@
             productHandle: item.product_handle,
             productId: item.product_id,
             productTitle: item.product_title,
+            itemVariant: getLineItemVariantLabel({
+              optionValues: item.variant_option_values,
+              title: item.variant_title,
+            }),
             unitPrice: item.unit_price,
           },
           String(item.quantity),
         ),
       ) ?? []
     )
+  }
+
+  function getCartItemImage(productHandle?: string, variantSku?: string) {
+    if (!productHandle || !(productHandle in vermouths)) return null
+
+    const staticData = vermouths[productHandle as Handle]
+    const configuredImage = variantSku ? staticData.variantImages?.[variantSku] : undefined
+    if (configuredImage) return configuredImage
+
+    const product = Object.values(data.categories)
+      .flat()
+      .find(({ handle }) => handle === productHandle)
+    if (product && getEligibleVariants(product).length > 1) return null
+
+    return {
+      altText: product?.title ?? productHandle,
+      url: staticData.image,
+    }
   }
 
   function makeQuantityResultHandler(context: CartItemAnalyticsContext) {
@@ -231,23 +256,38 @@
 
 {#snippet cartSnippet()}
   <ul>
-    {#each cart?.items as { product_id, product_handle, product_title, quantity, unit_price, id } (id)}
-      {@const { image } = vermouths[product_handle as Handle]}
+    {#each cart?.items as { product_id, product_handle, product_title, quantity, unit_price, variant_option_values, variant_sku, variant_title, id } (id)}
+      {@const itemVariant = getLineItemVariantLabel({
+        optionValues: variant_option_values,
+        title: variant_title,
+      })}
+      {@const itemImage = getCartItemImage(product_handle, variant_sku)}
       <li
         class="px-4 py-2 lg:p-5 flex border-b border-black first-of-type:border-t lg:first-of-type:border-t-0"
       >
-        <img
-          alt={product_title}
-          class="size-20 lg:size-16 object-cover"
-          width="66"
-          height="66"
-          loading="lazy"
-          srcset={thumbnailSrcSet(image)}
-          src="{image}/w=186,h=186,fit=cover"
-        />
+        {#if itemImage}
+          <img
+            alt={itemImage.altText}
+            class="size-20 object-cover lg:size-16"
+            width="66"
+            height="66"
+            loading="lazy"
+            srcset={thumbnailSrcSet(itemImage.url)}
+            src="{itemImage.url}/w=186,h=186,fit=cover"
+          />
+        {:else}
+          <div
+            aria-label="{product_title} – {itemVariant}. Billede mangler."
+            class="grid size-20 shrink-0 place-items-center border border-black bg-white/40 p-2 text-center text-[0.625rem] font-bold lg:size-16"
+            role="img"
+          >
+            Billede mangler
+          </div>
+        {/if}
         <div class="flex flex-col flex-1 gap-0 justify-between lg:flex-row lg:gap-0">
           <div class="flex-1 my-auto pt-6 lg:pt-0 lg:px-5 lg:max-w-80">
             <p class="text-sm font-bold">{product_title}</p>
+            <p class="text-xs">{itemVariant}</p>
             <dl class="text-xs flex justify-between">
               <dt>1 stk.</dt>
               <dd>{formattedPrice(unit_price)}</dd>
@@ -262,6 +302,7 @@
                 productHandle: product_handle,
                 productId: product_id,
                 productTitle: product_title,
+                itemVariant,
                 unitPrice: unit_price,
               })}
             >
@@ -283,6 +324,7 @@
                 productHandle: product_handle,
                 productId: product_id,
                 productTitle: product_title,
+                itemVariant,
                 unitPrice: unit_price,
               })}
             >

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -17,7 +17,6 @@
   import {
     getEligibleVariants,
     getLineItemVariantLabel,
-    getPresentationImage,
     getVariantImage,
     getVariantImageAltText,
   } from '$lib/helpers/product-variants'
@@ -221,12 +220,10 @@
     const product = getProductByHandle(productHandle)
     if (!product) return null
 
-    return getPresentationImage({
-      configuredImage,
-      fallbackAltText,
-      fallbackImage: staticData.image,
-      variantCount: getEligibleVariants(product).length,
-    })
+    if (configuredImage) return configuredImage
+    if (getEligibleVariants(product).length !== 1) return null
+
+    return { altText: fallbackAltText, url: staticData.image }
   }
 
   function makeQuantityResultHandler(context: CartItemAnalyticsContext) {
@@ -296,23 +293,15 @@
       <li
         class="px-4 py-2 lg:p-5 flex border-b border-black first-of-type:border-t lg:first-of-type:border-t-0"
       >
-        {#if itemImage}
-          <img
-            alt={itemImage.altText}
-            class="size-20 object-cover lg:size-16"
-            width="66"
-            height="66"
-            loading="lazy"
-            srcset={thumbnailSrcSet(itemImage.url)}
-            src="{itemImage.url}/w=186,h=186,fit=cover"
-          />
-        {:else}
-          <p
-            class="flex size-20 shrink-0 items-center justify-center p-1 text-center text-[10px] lg:size-16"
-          >
-            {itemImageAltText}
-          </p>
-        {/if}
+        <img
+          alt={itemImage?.altText ?? itemImageAltText}
+          class="size-20 object-cover lg:size-16"
+          width="66"
+          height="66"
+          loading="lazy"
+          srcset={itemImage ? thumbnailSrcSet(itemImage.url) : undefined}
+          src={itemImage ? `${itemImage.url}/w=186,h=186,fit=cover` : undefined}
+        />
         <div class="flex flex-col flex-1 gap-0 justify-between lg:flex-row lg:gap-0">
           <div class="flex-1 my-auto pt-6 lg:pt-0 lg:px-5 lg:max-w-80">
             <p class="text-sm font-bold">{product_title}</p>

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -2,7 +2,7 @@
   import type { ActionResult } from '@sveltejs/kit'
   import { onMount } from 'svelte'
   import type { PageProps } from './$types'
-  import { vermouths, type Handle } from '$lib/data/products'
+  import { getVermouth } from '$lib/data/products'
   import {
     trackAddShippingInfo,
     trackBeginCheckout,
@@ -15,7 +15,9 @@
   } from '$lib/helpers/analytics'
   import { thumbnailSrcSet } from '$lib/helpers/images'
   import {
+    getEligibleVariants,
     getLineItemVariantLabel,
+    getPresentationImage,
     getVariantImage,
     getVariantImageAltText,
   } from '$lib/helpers/product-variants'
@@ -79,7 +81,7 @@
   }
   type CategoryHandle = keyof typeof GA_CATEGORY_LABEL_BY_HANDLE
 
-  function getProductByHandle(productHandle?: string) {
+  function getProductByHandle(productHandle?: string | null) {
     if (!productHandle) return null
 
     return (
@@ -162,7 +164,7 @@
 
   function toGaItem(context: CartItemAnalyticsContext, quantity: string): GaListItem {
     const handle = context.productHandle
-    const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
+    const staticData = getVermouth(handle)
     const categoryHandle = getCategoryHandleByProductHandle(handle)
 
     return {
@@ -203,13 +205,12 @@
   }
 
   function getCartItemImage(
-    productHandle: Handle,
-    productTitle: string,
-    itemVariant: string,
+    productHandle: string | null | undefined,
+    fallbackAltText: string,
     variantSku?: string,
   ) {
-    const staticData = vermouths[productHandle]
-    const fallbackAltText = getVariantImageAltText(productTitle, itemVariant)
+    const staticData = getVermouth(productHandle)
+    if (!staticData) return null
     const configuredImage = variantSku
       ? getVariantImage({
           fallbackAltText,
@@ -217,12 +218,15 @@
           variantImages: staticData.variantImages,
         })
       : null
-    if (configuredImage) return configuredImage
+    const product = getProductByHandle(productHandle)
+    if (!product) return null
 
-    return {
-      altText: fallbackAltText,
-      url: staticData.image,
-    }
+    return getPresentationImage({
+      configuredImage,
+      fallbackAltText,
+      fallbackImage: staticData.image,
+      variantCount: getEligibleVariants(product).length,
+    })
   }
 
   function makeQuantityResultHandler(context: CartItemAnalyticsContext) {
@@ -284,24 +288,31 @@
         sku: variant_sku,
         title: variant_title,
       })}
-      {@const itemImage = getCartItemImage(
-        product_handle as Handle,
+      {@const itemImageAltText = getVariantImageAltText(
         product_title ?? product_handle ?? 'Produkt',
         itemVariant,
-        variant_sku,
       )}
+      {@const itemImage = getCartItemImage(product_handle, itemImageAltText, variant_sku)}
       <li
         class="px-4 py-2 lg:p-5 flex border-b border-black first-of-type:border-t lg:first-of-type:border-t-0"
       >
-        <img
-          alt={itemImage.altText}
-          class="size-20 object-cover lg:size-16"
-          width="66"
-          height="66"
-          loading="lazy"
-          srcset={thumbnailSrcSet(itemImage.url)}
-          src="{itemImage.url}/w=186,h=186,fit=cover"
-        />
+        {#if itemImage}
+          <img
+            alt={itemImage.altText}
+            class="size-20 object-cover lg:size-16"
+            width="66"
+            height="66"
+            loading="lazy"
+            srcset={thumbnailSrcSet(itemImage.url)}
+            src="{itemImage.url}/w=186,h=186,fit=cover"
+          />
+        {:else}
+          <p
+            class="flex size-20 shrink-0 items-center justify-center p-1 text-center text-[10px] lg:size-16"
+          >
+            {itemImageAltText}
+          </p>
+        {/if}
         <div class="flex flex-col flex-1 gap-0 justify-between lg:flex-row lg:gap-0">
           <div class="flex-1 my-auto pt-6 lg:pt-0 lg:px-5 lg:max-w-80">
             <p class="text-sm font-bold">{product_title}</p>

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -14,7 +14,11 @@
     type GaListItem,
   } from '$lib/helpers/analytics'
   import { thumbnailSrcSet } from '$lib/helpers/images'
-  import { getEligibleVariants, getLineItemVariantLabel } from '$lib/helpers/product-variants'
+  import {
+    getEligibleVariants,
+    getLineItemVariantLabel,
+    getVariantImage,
+  } from '$lib/helpers/product-variants'
   import Checkbox from '$lib/components/form-controls/checkbox.svelte'
   import Form from '$lib/components/form-controls/form.svelte'
   import Input from '$lib/components/form-controls/input.svelte'
@@ -68,7 +72,7 @@
     cartItemId: string
     productHandle?: string
     productTitle?: string
-    itemVariant?: string
+    itemVariant: string
     unitPrice: number
     previousQuantity: number
     productId?: string
@@ -190,7 +194,12 @@
     if (!productHandle || !(productHandle in vermouths)) return null
 
     const staticData = vermouths[productHandle as Handle]
-    const configuredImage = variantSku ? staticData.variantImages?.[variantSku] : undefined
+    const configuredImage = variantSku
+      ? getVariantImage({
+          variantSku,
+          variantImages: staticData.variantImages,
+        })
+      : null
     if (configuredImage) return configuredImage
 
     const product = Object.values(data.categories)

--- a/src/routes/kurv/+page.svelte
+++ b/src/routes/kurv/+page.svelte
@@ -15,9 +15,9 @@
   } from '$lib/helpers/analytics'
   import { thumbnailSrcSet } from '$lib/helpers/images'
   import {
-    getEligibleVariants,
     getLineItemVariantLabel,
     getVariantImage,
+    getVariantImageAltText,
   } from '$lib/helpers/product-variants'
   import Checkbox from '$lib/components/form-controls/checkbox.svelte'
   import Form from '$lib/components/form-controls/form.svelte'
@@ -78,6 +78,16 @@
     productId?: string
   }
   type CategoryHandle = keyof typeof GA_CATEGORY_LABEL_BY_HANDLE
+
+  function getProductByHandle(productHandle?: string) {
+    if (!productHandle) return null
+
+    return (
+      Object.values(data.categories)
+        .flat()
+        .find(({ handle }) => handle === productHandle) ?? null
+    )
+  }
 
   function handleCheckoutResult(result: ActionResult) {
     if (result.type === 'redirect') {
@@ -180,6 +190,8 @@
             productTitle: item.product_title,
             itemVariant: getLineItemVariantLabel({
               optionValues: item.variant_option_values,
+              product: getProductByHandle(item.product_handle),
+              sku: item.variant_sku,
               title: item.variant_title,
             }),
             unitPrice: item.unit_price,
@@ -190,25 +202,25 @@
     )
   }
 
-  function getCartItemImage(productHandle?: string, variantSku?: string) {
-    if (!productHandle || !(productHandle in vermouths)) return null
-
-    const staticData = vermouths[productHandle as Handle]
+  function getCartItemImage(
+    productHandle: Handle,
+    productTitle: string,
+    itemVariant: string,
+    variantSku?: string,
+  ) {
+    const staticData = vermouths[productHandle]
+    const fallbackAltText = getVariantImageAltText(productTitle, itemVariant)
     const configuredImage = variantSku
       ? getVariantImage({
+          fallbackAltText,
           variantSku,
           variantImages: staticData.variantImages,
         })
       : null
     if (configuredImage) return configuredImage
 
-    const product = Object.values(data.categories)
-      .flat()
-      .find(({ handle }) => handle === productHandle)
-    if (product && getEligibleVariants(product).length > 1) return null
-
     return {
-      altText: product?.title ?? productHandle,
+      altText: fallbackAltText,
       url: staticData.image,
     }
   }
@@ -268,31 +280,28 @@
     {#each cart?.items as { product_id, product_handle, product_title, quantity, unit_price, variant_option_values, variant_sku, variant_title, id } (id)}
       {@const itemVariant = getLineItemVariantLabel({
         optionValues: variant_option_values,
+        product: getProductByHandle(product_handle),
+        sku: variant_sku,
         title: variant_title,
       })}
-      {@const itemImage = getCartItemImage(product_handle, variant_sku)}
+      {@const itemImage = getCartItemImage(
+        product_handle as Handle,
+        product_title ?? product_handle ?? 'Produkt',
+        itemVariant,
+        variant_sku,
+      )}
       <li
         class="px-4 py-2 lg:p-5 flex border-b border-black first-of-type:border-t lg:first-of-type:border-t-0"
       >
-        {#if itemImage}
-          <img
-            alt={itemImage.altText}
-            class="size-20 object-cover lg:size-16"
-            width="66"
-            height="66"
-            loading="lazy"
-            srcset={thumbnailSrcSet(itemImage.url)}
-            src="{itemImage.url}/w=186,h=186,fit=cover"
-          />
-        {:else}
-          <div
-            aria-label="{product_title} – {itemVariant}. Billede mangler."
-            class="grid size-20 shrink-0 place-items-center border border-black bg-white/40 p-2 text-center text-[0.625rem] font-bold lg:size-16"
-            role="img"
-          >
-            Billede mangler
-          </div>
-        {/if}
+        <img
+          alt={itemImage.altText}
+          class="size-20 object-cover lg:size-16"
+          width="66"
+          height="66"
+          loading="lazy"
+          srcset={thumbnailSrcSet(itemImage.url)}
+          src="{itemImage.url}/w=186,h=186,fit=cover"
+        />
         <div class="flex flex-col flex-1 gap-0 justify-between lg:flex-row lg:gap-0">
           <div class="flex-1 my-auto pt-6 lg:pt-0 lg:px-5 lg:max-w-80">
             <p class="text-sm font-bold">{product_title}</p>

--- a/src/routes/ordrer/[id]/+page.svelte
+++ b/src/routes/ordrer/[id]/+page.svelte
@@ -48,6 +48,16 @@
     return null
   }
 
+  function getProductByHandle(productHandle?: string | null) {
+    if (!productHandle) return null
+
+    return (
+      Object.values(data.categories)
+        .flat()
+        .find(({ handle }) => handle === productHandle) ?? null
+    )
+  }
+
   function toGaItems() {
     return order.items!.map((item): GaListItem => {
       const handle = item.product_handle as Handle | null
@@ -64,6 +74,8 @@
           : GA_MISSING.itemCategory,
         item_variant: getLineItemVariantLabel({
           optionValues: item.variant_option_values,
+          product: getProductByHandle(item.product_handle),
+          sku: item.variant_sku,
           title: item.variant_title,
         }),
         quantity: String(item.quantity),
@@ -172,8 +184,14 @@
 
   <div class="lg:max-w-[1068px] mb-6 mx-auto text-sm lg:text-base">
     {#each order.items as item (item.id)}
+      {@const itemVariant = getLineItemVariantLabel({
+        optionValues: item.variant_option_values,
+        product: getProductByHandle(item.product_handle),
+        sku: item.variant_sku,
+        title: item.variant_title,
+      })}
       <div class="flex justify-between items-center py-2 border-b border-black">
-        <span>{item.product_title} x {item.quantity}</span>
+        <span>{item.product_title} · {itemVariant} x {item.quantity}</span>
         <span>{formatPrice(item.unit_price * item.quantity, order.currency_code, locale)}</span>
       </div>
     {/each}

--- a/src/routes/ordrer/[id]/+page.svelte
+++ b/src/routes/ordrer/[id]/+page.svelte
@@ -14,6 +14,7 @@
   import ModalDialog from '$lib/components/modal-dialog.svelte'
   import type { PageData } from './$types'
   import { formatPrice } from '$lib/helpers/numbers'
+  import { getLineItemVariantLabel } from '$lib/helpers/product-variants'
 
   const { data }: { data: PageData } = $props()
   const { locale, order } = $derived(data)
@@ -61,6 +62,10 @@
         item_category: categoryHandle
           ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
           : GA_MISSING.itemCategory,
+        item_variant: getLineItemVariantLabel({
+          optionValues: item.variant_option_values,
+          title: item.variant_title,
+        }),
         quantity: String(item.quantity),
       }
     })

--- a/src/routes/sortiment/+page.svelte
+++ b/src/routes/sortiment/+page.svelte
@@ -12,6 +12,7 @@
     trackViewItemList,
     type GaListItem,
   } from '$lib/helpers/analytics'
+  import { getDefaultVariant, getVariantLabel } from '$lib/helpers/product-variants'
   import { resolve } from '$app/paths'
   import type { HttpTypes } from '@medusajs/types'
 
@@ -44,7 +45,8 @@
     const categoryHandle = getCategoryHandle(product)
     const handle = typeof product.handle === 'string' ? product.handle : null
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
-    const price = product.variants?.[0]?.calculated_price?.calculated_amount
+    const variant = getDefaultVariant(product)
+    const price = variant?.calculated_price?.calculated_amount
 
     return {
       item_id: product.id || GA_MISSING.itemId,
@@ -54,6 +56,7 @@
       item_category: categoryHandle
         ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
         : GA_MISSING.itemCategory,
+      item_variant: variant ? getVariantLabel(variant) : undefined,
       item_list_name: categoryHandle || GA_MISSING.itemListName,
       item_list_id: categoryHandle ? categoryHandle.toUpperCase() : GA_MISSING.itemListId,
       index,

--- a/src/routes/sortiment/+page.svelte
+++ b/src/routes/sortiment/+page.svelte
@@ -46,7 +46,7 @@
     const handle = typeof product.handle === 'string' ? product.handle : null
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
     const variant = getDefaultVariant(product)
-    const price = variant?.calculated_price?.calculated_amount
+    const price = variant.calculated_price?.calculated_amount
 
     return {
       item_id: product.id || GA_MISSING.itemId,
@@ -56,7 +56,7 @@
       item_category: categoryHandle
         ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
         : GA_MISSING.itemCategory,
-      item_variant: variant ? getVariantLabel(variant) : undefined,
+      item_variant: getVariantLabel(variant),
       item_list_name: categoryHandle || GA_MISSING.itemListName,
       item_list_id: categoryHandle ? categoryHandle.toUpperCase() : GA_MISSING.itemListId,
       index,

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -281,8 +281,9 @@
     <p class=" font-bold text-xs mb-4">{product.subtitle}</p>
     <h1 class="text-2xl mb-2">{product.title}</h1>
     <p class="font-bold text-xs mb-4">{origin}</p>
-    <p class="mb-2 text-sm font-bold">{variantPresentation.packaging}</p>
-    <p class="mb-4 text-xs">{variantPresentation.size}</p>
+    <p class="mb-4 text-sm font-bold">
+      {variantPresentation.packaging} · {variantPresentation.size}
+    </p>
     {#if priceDisplay}
       <div class="mb-6">
         <p class="text-base font-bold">

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -13,7 +13,6 @@
   import {
     getDefaultVariant,
     getEligibleVariants,
-    getPresentationImage,
     getVariantBySku,
     getVariantImage,
     getVariantImageAltText,
@@ -66,12 +65,8 @@
     }),
   )
   const variantImage = $derived(
-    getPresentationImage({
-      configuredImage: configuredVariantImage,
-      fallbackAltText: variantImageAltText,
-      fallbackImage: image,
-      variantCount: eligibleVariants.length,
-    }),
+    configuredVariantImage ??
+      (eligibleVariants.length === 1 ? { altText: variantImageAltText, url: image } : null),
   )
   const priceDisplay = $derived(getVariantPriceDisplay(variant, region.currency_code, locale))
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant.id))
@@ -377,21 +372,15 @@
   >
     <div class="aspect-square w-full max-w-[896px] lg:mx-auto">
       {#key variant.sku}
-        {#if variantImage}
-          <img
-            alt={variantImage.altText}
-            class="h-full w-full object-contain"
-            srcset={squareSrcSet(variantImage.url)}
-            src="{variantImage.url}/w=400,h=400,fit=cover"
-            sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
-            width="896"
-            height="896"
-          />
-        {:else}
-          <p class="flex h-full items-center justify-center p-6 text-center text-sm">
-            {variantImageAltText}
-          </p>
-        {/if}
+        <img
+          alt={variantImage?.altText ?? variantImageAltText}
+          class="h-full w-full object-contain"
+          srcset={variantImage ? squareSrcSet(variantImage.url) : undefined}
+          src={variantImage ? `${variantImage.url}/w=400,h=400,fit=cover` : undefined}
+          sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
+          width="896"
+          height="896"
+        />
       {/key}
     </div>
   </div>

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -326,7 +326,7 @@
     </div>
     {#if eligibleVariants.length > 1}
       <div class="mb-6 mt-6">
-        <form action={page.url.pathname} method="GET">
+        <form action={page.url.pathname} data-sveltekit-noscroll method="GET">
           {#each variantFormParams as [name, value], index (index)}
             <input type="hidden" {name} {value} />
           {/each}

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -17,7 +17,7 @@
     getVariantImage,
     getVariantLabel,
     getVariantPresentation,
-    type ProductVariant,
+    type EligibleProductVariant,
   } from '$lib/helpers/product-variants'
   import { squareSrcSet } from '$lib/helpers/images'
   import { getVariantPriceDisplay } from '$lib/helpers/prices'
@@ -42,19 +42,24 @@
   )
   const productDescription = $derived(product.description ?? '')
   const eligibleVariants = $derived(getEligibleVariants(product))
-  const defaultVariant = $derived(getDefaultVariant(product) ?? eligibleVariants[0]!)
+  const defaultVariant = $derived(getDefaultVariant(product))
   let selectedSku = $state(page.url.searchParams.get('variant') ?? '')
   const variant = $derived(getVariantBySku(eligibleVariants, selectedSku) ?? defaultVariant)
   const variantPresentation = $derived(getVariantPresentation(variant))
   const variantLabel = $derived(getVariantLabel(variant))
   const variantImage = $derived(
     getVariantImage({
-      fallbackImage: image,
-      productTitle: product.title,
-      variant,
-      variantCount: eligibleVariants.length,
+      variantSku: variant.sku,
       variantImages,
-    }),
+    }) ??
+      (eligibleVariants.length === 1
+        ? {
+            altText: [product.title, variantPresentation.packaging, variantPresentation.size]
+              .filter(Boolean)
+              .join(' – '),
+            url: image,
+          }
+        : null),
   )
   const priceDisplay = $derived(getVariantPriceDisplay(variant, region.currency_code, locale))
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant.id))
@@ -62,7 +67,7 @@
     eligibleVariants.map((eligibleVariant) => ({
       label: getVariantLabel(eligibleVariant).replace(' — ', ' · '),
       price: getVariantPriceDisplay(eligibleVariant, region.currency_code, locale)?.current ?? '',
-      value: eligibleVariant.sku!,
+      value: eligibleVariant.sku,
     })),
   )
   const reviews = $derived(data.reviews)
@@ -115,7 +120,10 @@
     return null
   }
 
-  function toGaItem(quantity: string, selectedVariant: ProductVariant = variant): GaListItem {
+  function toGaItem(
+    quantity: string,
+    selectedVariant: EligibleProductVariant = variant,
+  ): GaListItem {
     const handle = typeof product.handle === 'string' ? product.handle : null
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
     const price = selectedVariant.calculated_price?.calculated_amount
@@ -142,7 +150,7 @@
     nextUrl.searchParams.set('variant', event.currentTarget.value)
     const productSlug = slug ?? product.handle ?? ''
     buttonState = 'default'
-    selectedSku = selectedVariant.sku ?? ''
+    selectedSku = selectedVariant.sku
     replaceState(
       resolve(
         `/sortiment/${encodeURIComponent(productSlug)}?${nextUrl.searchParams}${nextUrl.hash}`,
@@ -228,7 +236,7 @@
   }
 
   afterNavigate(() => {
-    selectedSku = page.url.searchParams.get('variant') ?? defaultVariant.sku ?? ''
+    selectedSku = page.url.searchParams.get('variant') ?? defaultVariant.sku
     trackViewItem({
       currency: region.currency_code.toUpperCase(),
       item: toGaItem('1'),
@@ -299,7 +307,7 @@
         onResult={handleFormResult}
       >
         <fieldset disabled={purchasesPaused}>
-          <input name="variant_id" type="hidden" value={variant?.id} />
+          <input name="variant_id" type="hidden" value={variant.id} />
           <input name="cart_item_id" type="hidden" value={cartItem?.id} />
           <div class="flex items-center justify-between md:gap-4">
             <button
@@ -323,7 +331,7 @@
           name="variant"
           onChange={selectVariant}
           options={selectorOptions}
-          selected={variant.sku ?? ''}
+          selected={variant.sku}
         />
       </div>
     {/if}

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -263,10 +263,10 @@
 <section class="split-content border-b border-black lg:flex-row-reverse">
   <div class="copy">
     {#if hasReviews}
-      <div class="mb-8 flex flex-col items-start gap-3 text-brand-blue">
-        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+      <div class="mb-1 text-brand-blue">
+        <div class="flex items-center gap-3">
           <p
-            class="relative inline-block text-[1.9375rem]/[1.9375rem] font-bold tracking-normal"
+            class="relative inline-block shrink-0 text-base font-bold leading-none tracking-normal"
             aria-label="{formattedAverageRating} ud af 5 stjerner"
           >
             <span aria-hidden="true" class="text-brand-blue/25">★★★★★</span>
@@ -278,19 +278,23 @@
               ★★★★★
             </span>
           </p>
-          <p class="text-xs font-bold text-black">{reviewCountLabel}</p>
+          <a
+            class="whitespace-nowrap text-xs font-bold text-brand-blue underline underline-offset-2"
+            href="#product-reviews"
+          >
+            {reviewCountLabel}
+          </a>
         </div>
-        <a class="text-xs font-bold underline underline-offset-2" href="#product-reviews">
-          Læs {reviewCountLabel}
-        </a>
       </div>
     {/if}
-    <p class=" font-bold text-xs mb-4">{product.subtitle}</p>
-    <p class="mb-2 text-sm">
-      {variantPresentation.packaging} · {variantPresentation.size} · {alcoholPercentage}
-    </p>
-    <h1 class="text-2xl mb-2">{product.title}</h1>
-    <p class="font-bold text-xs mb-4">{origin}</p>
+    <p class="mb-6 text-xs font-bold">{product.subtitle}</p>
+    <div class="mb-6">
+      <p class="text-sm">
+        {variantPresentation.packaging} · {variantPresentation.size} · {alcoholPercentage}
+      </p>
+      <h1 class="text-2xl">{product.title}</h1>
+      <p class="text-xs font-bold">{origin}</p>
+    </div>
     {#if priceDisplay}
       <div class="mb-6">
         <p class="text-base font-bold">

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -326,10 +326,7 @@
     </div>
     {#if eligibleVariants.length > 1}
       <div class="mb-6 mt-6">
-        <form
-          action={resolve(`/sortiment/${encodeURIComponent(product.handle ?? slug ?? '')}`)}
-          method="GET"
-        >
+        <form action={page.url.pathname} method="GET">
           {#each variantFormParams as [name, value], index (index)}
             <input type="hidden" {name} {value} />
           {/each}

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -13,6 +13,7 @@
   import {
     getDefaultVariant,
     getEligibleVariants,
+    getPresentationImage,
     getVariantBySku,
     getVariantImage,
     getVariantImageAltText,
@@ -57,15 +58,20 @@
   const variantPresentation = $derived(getVariantPresentation(variant))
   const variantLabel = $derived(getVariantLabel(variant))
   const variantImageAltText = $derived(getVariantImageAltText(product.title, variantLabel))
-  const variantImage = $derived(
+  const configuredVariantImage = $derived(
     getVariantImage({
       fallbackAltText: variantImageAltText,
       variantSku: variant.sku,
       variantImages,
-    }) ?? {
-      altText: variantImageAltText,
-      url: image,
-    },
+    }),
+  )
+  const variantImage = $derived(
+    getPresentationImage({
+      configuredImage: configuredVariantImage,
+      fallbackAltText: variantImageAltText,
+      fallbackImage: image,
+      variantCount: eligibleVariants.length,
+    }),
   )
   const priceDisplay = $derived(getVariantPriceDisplay(variant, region.currency_code, locale))
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant.id))
@@ -253,8 +259,8 @@
 <Seo
   title={product.title}
   description={productDescription}
-  image={`${variantImage.url}/w=800,h=800,fit=cover`}
-  imageAlt={variantImage.altText}
+  image={variantImage ? `${variantImage.url}/w=800,h=800,fit=cover` : undefined}
+  imageAlt={variantImage?.altText}
   url={`https://www.vermouth.nu/sortiment/${encodeURIComponent(product.handle ?? slug ?? '')}`}
 />
 
@@ -371,15 +377,21 @@
   >
     <div class="aspect-square w-full max-w-[896px] lg:mx-auto">
       {#key variant.sku}
-        <img
-          alt={variantImage.altText}
-          class="h-full w-full object-contain"
-          srcset={squareSrcSet(variantImage.url)}
-          src="{variantImage.url}/w=400,h=400,fit=cover"
-          sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
-          width="896"
-          height="896"
-        />
+        {#if variantImage}
+          <img
+            alt={variantImage.altText}
+            class="h-full w-full object-contain"
+            srcset={squareSrcSet(variantImage.url)}
+            src="{variantImage.url}/w=400,h=400,fit=cover"
+            sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
+            width="896"
+            height="896"
+          />
+        {:else}
+          <p class="flex h-full items-center justify-center p-6 text-center text-sm">
+            {variantImageAltText}
+          </p>
+        {/if}
       {/key}
     </div>
   </div>

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -286,11 +286,11 @@
       </div>
     {/if}
     <p class=" font-bold text-xs mb-4">{product.subtitle}</p>
-    <h1 class="text-2xl mb-2">{product.title}</h1>
-    <p class="font-bold text-xs mb-4">{origin}</p>
-    <p class="mb-4 text-sm font-bold">
+    <p class="mb-2 text-sm">
       {variantPresentation.packaging} · {variantPresentation.size} · {alcoholPercentage}
     </p>
+    <h1 class="text-2xl mb-2">{product.title}</h1>
+    <p class="font-bold text-xs mb-4">{origin}</p>
     {#if priceDisplay}
       <div class="mb-6">
         <p class="text-base font-bold">

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -15,12 +15,13 @@
     getEligibleVariants,
     getVariantBySku,
     getVariantImage,
+    getVariantImageAltText,
     getVariantLabel,
+    getVariantPriceDisplay,
     getVariantPresentation,
     type EligibleProductVariant,
   } from '$lib/helpers/product-variants'
   import { squareSrcSet } from '$lib/helpers/images'
-  import { getVariantPriceDisplay } from '$lib/helpers/prices'
   import { Form, QuantitySelector, RadioGroup } from '$lib/components/form-controls'
   import Marquee from '$lib/components/marquee.svelte'
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
@@ -47,19 +48,16 @@
   const variant = $derived(getVariantBySku(eligibleVariants, selectedSku) ?? defaultVariant)
   const variantPresentation = $derived(getVariantPresentation(variant))
   const variantLabel = $derived(getVariantLabel(variant))
+  const variantImageAltText = $derived(getVariantImageAltText(product.title, variantLabel))
   const variantImage = $derived(
     getVariantImage({
+      fallbackAltText: variantImageAltText,
       variantSku: variant.sku,
       variantImages,
-    }) ??
-      (eligibleVariants.length === 1
-        ? {
-            altText: [product.title, variantPresentation.packaging, variantPresentation.size]
-              .filter(Boolean)
-              .join(' – '),
-            url: image,
-          }
-        : null),
+    }) ?? {
+      altText: variantImageAltText,
+      url: image,
+    },
   )
   const priceDisplay = $derived(getVariantPriceDisplay(variant, region.currency_code, locale))
   const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant.id))
@@ -244,11 +242,19 @@
   })
 </script>
 
+<svelte:head>
+  <link
+    rel="canonical"
+    href={`https://www.vermouth.nu/sortiment/${encodeURIComponent(product.handle ?? slug ?? '')}`}
+  />
+</svelte:head>
+
 <Seo
   title={product.title}
   description={productDescription}
-  image={variantImage ? `${variantImage.url}/w=800,h=800,fit=cover` : ''}
-  imageAlt={variantImage?.altText ?? `${product.title} – ${variantLabel}`}
+  image={`${variantImage.url}/w=800,h=800,fit=cover`}
+  imageAlt={variantImage.altText}
+  url={`https://www.vermouth.nu/sortiment/${encodeURIComponent(product.handle ?? slug ?? '')}`}
 />
 
 <Marquee text="{product.title} //" theme="red"></Marquee>
@@ -325,9 +331,10 @@
       </Form>
     </div>
     {#if eligibleVariants.length > 1}
-      <div class="variant-options mb-6 mt-6">
+      <div class="mb-6 mt-6">
         <RadioGroup
           groupLabel="Vælg format"
+          layout="responsive-grid"
           name="variant"
           onChange={selectVariant}
           options={selectorOptions}
@@ -353,25 +360,15 @@
   >
     <div class="aspect-square w-full max-w-[896px] lg:mx-auto">
       {#key variant.sku}
-        {#if variantImage}
-          <img
-            alt={variantImage.altText}
-            class="h-full w-full object-contain"
-            srcset={squareSrcSet(variantImage.url)}
-            src="{variantImage.url}/w=400,h=400,fit=cover"
-            sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
-            width="896"
-            height="896"
-          />
-        {:else}
-          <div
-            class="flex h-full w-full items-center justify-center border border-black bg-white/40 p-8 text-center text-sm font-bold"
-            role="img"
-            aria-label="{product.title} – {variantLabel}. Billede mangler."
-          >
-            Billede mangler
-          </div>
-        {/if}
+        <img
+          alt={variantImage.altText}
+          class="h-full w-full object-contain"
+          srcset={squareSrcSet(variantImage.url)}
+          src="{variantImage.url}/w=400,h=400,fit=cover"
+          sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
+          width="896"
+          height="896"
+        />
       {/key}
     </div>
   </div>
@@ -530,32 +527,3 @@
   <p>Op dit cocktails-game med Vermouth</p>
   <a class="btn" href={resolve('/inspiration')}>DYK NED I VORES MANGE DRINKSOPSKRIFTER</a>
 </section>
-
-<style>
-  .variant-options :global(fieldset > ul > li label) {
-    padding-inline-end: 1rem;
-  }
-
-  .variant-options :global(fieldset > ul > li label > div > div) {
-    gap: 0.75rem;
-  }
-
-  .variant-options :global(fieldset > ul > li label > div > div > p:last-child) {
-    margin-inline-start: auto;
-    text-align: end;
-    white-space: nowrap;
-  }
-
-  @media (min-width: 1024px) {
-    .variant-options :global(fieldset > ul) {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.75rem;
-      border: 0;
-    }
-
-    .variant-options :global(fieldset > ul > li) {
-      border: 1px solid currentColor;
-    }
-  }
-</style>

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -27,7 +27,7 @@
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import ProductSliders from '$lib/components/product-sliders.svelte'
   import Seo from '$lib/components/SEO.svelte'
-  import { afterNavigate, goto, replaceState } from '$app/navigation'
+  import { afterNavigate, goto } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
 
@@ -44,8 +44,9 @@
   const productDescription = $derived(product.description ?? '')
   const eligibleVariants = $derived(getEligibleVariants(product))
   const defaultVariant = $derived(getDefaultVariant(product))
-  let selectedSku = $state(page.url.searchParams.get('variant') ?? '')
-  const variant = $derived(getVariantBySku(eligibleVariants, selectedSku) ?? defaultVariant)
+  const variant = $derived(
+    getVariantBySku(eligibleVariants, page.url.searchParams.get('variant')) ?? defaultVariant,
+  )
   const variantPresentation = $derived(getVariantPresentation(variant))
   const variantLabel = $derived(getVariantLabel(variant))
   const variantImageAltText = $derived(getVariantImageAltText(product.title, variantLabel))
@@ -67,6 +68,9 @@
       price: getVariantPriceDisplay(eligibleVariant, region.currency_code, locale)?.current ?? '',
       value: eligibleVariant.sku,
     })),
+  )
+  const variantFormParams = $derived(
+    [...page.url.searchParams.entries()].filter(([name]) => name !== 'variant'),
   )
   const reviews = $derived(data.reviews)
   const visibleReviews = $derived(data.reviews.reviews)
@@ -144,21 +148,8 @@
     const selectedVariant = getVariantBySku(eligibleVariants, event.currentTarget.value)
     if (!selectedVariant) return
 
-    const nextUrl = new URL(page.url)
-    nextUrl.searchParams.set('variant', event.currentTarget.value)
-    const productSlug = slug ?? product.handle ?? ''
     buttonState = 'default'
-    selectedSku = selectedVariant.sku
-    replaceState(
-      resolve(
-        `/sortiment/${encodeURIComponent(productSlug)}?${nextUrl.searchParams}${nextUrl.hash}`,
-      ),
-      page.state,
-    )
-    trackViewItem({
-      currency: region.currency_code.toUpperCase(),
-      item: toGaItem('1', selectedVariant),
-    })
+    event.currentTarget.form?.requestSubmit()
   }
 
   function getRatingPercentage(rating: number) {
@@ -233,8 +224,11 @@
     }
   }
 
-  afterNavigate(() => {
-    selectedSku = page.url.searchParams.get('variant') ?? defaultVariant.sku
+  afterNavigate(({ to }) => {
+    const productSlug = slug ?? product.handle ?? ''
+    const productPath = resolve(`/sortiment/${encodeURIComponent(productSlug)}`)
+    if (to?.url.pathname !== productPath) return
+
     trackViewItem({
       currency: region.currency_code.toUpperCase(),
       item: toGaItem('1'),
@@ -332,14 +326,22 @@
     </div>
     {#if eligibleVariants.length > 1}
       <div class="mb-6 mt-6">
-        <RadioGroup
-          groupLabel="Vælg format"
-          layout="responsive-grid"
-          name="variant"
-          onChange={selectVariant}
-          options={selectorOptions}
-          selected={variant.sku}
-        />
+        <form
+          action={resolve(`/sortiment/${encodeURIComponent(product.handle ?? slug ?? '')}`)}
+          method="GET"
+        >
+          {#each variantFormParams as [name, value], index (index)}
+            <input type="hidden" {name} {value} />
+          {/each}
+          <RadioGroup
+            groupLabel="Vælg format"
+            layout="responsive-grid"
+            name="variant"
+            onChange={selectVariant}
+            options={selectorOptions}
+            selected={variant.sku}
+          />
+        </form>
       </div>
     {/if}
     <a

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -38,9 +38,16 @@
 
   const { red, white, other, packs } = $derived(data.categories)
   const { cart, locale, product, purchasesPaused, region } = $derived(data)
-  const { extraImages, image, origin, recommendation, scores, taste, variantImages } = $derived(
-    vermouths[product.handle as Handle],
-  )
+  const {
+    alcoholPercentage,
+    extraImages,
+    image,
+    origin,
+    recommendation,
+    scores,
+    taste,
+    variantImages,
+  } = $derived(vermouths[product.handle as Handle])
   const productDescription = $derived(product.description ?? '')
   const eligibleVariants = $derived(getEligibleVariants(product))
   const defaultVariant = $derived(getDefaultVariant(product))
@@ -282,7 +289,7 @@
     <h1 class="text-2xl mb-2">{product.title}</h1>
     <p class="font-bold text-xs mb-4">{origin}</p>
     <p class="mb-4 text-sm font-bold">
-      {variantPresentation.packaging} · {variantPresentation.size}
+      {variantPresentation.packaging} · {variantPresentation.size} · {alcoholPercentage}
     </p>
     {#if priceDisplay}
       <div class="mb-6">

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -10,17 +10,25 @@
     trackViewItem,
     type GaListItem,
   } from '$lib/helpers/analytics'
+  import {
+    getDefaultVariant,
+    getEligibleVariants,
+    getVariantBySku,
+    getVariantImage,
+    getVariantLabel,
+    getVariantPresentation,
+    type ProductVariant,
+  } from '$lib/helpers/product-variants'
   import { squareSrcSet } from '$lib/helpers/images'
-  import { getProductPriceDisplay } from '$lib/helpers/prices'
-  import { Form, QuantitySelector } from '$lib/components/form-controls'
+  import { getVariantPriceDisplay } from '$lib/helpers/prices'
+  import { Form, QuantitySelector, RadioGroup } from '$lib/components/form-controls'
   import Marquee from '$lib/components/marquee.svelte'
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import ProductSliders from '$lib/components/product-sliders.svelte'
   import Seo from '$lib/components/SEO.svelte'
-  import { goto } from '$app/navigation'
+  import { afterNavigate, goto, replaceState } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
-  import { untrack } from 'svelte'
 
   const { slug } = $derived(page.params)
   const { data }: PageProps = $props()
@@ -29,13 +37,34 @@
 
   const { red, white, other, packs } = $derived(data.categories)
   const { cart, locale, product, purchasesPaused, region } = $derived(data)
-  const { extraImages, image, origin, recommendation, scores, taste } = $derived(
+  const { extraImages, image, origin, recommendation, scores, taste, variantImages } = $derived(
     vermouths[product.handle as Handle],
   )
   const productDescription = $derived(product.description ?? '')
-  const variant = $derived(product.variants?.[0])
-  const priceDisplay = $derived(getProductPriceDisplay(product, region.currency_code, locale))
-  const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant?.id))
+  const eligibleVariants = $derived(getEligibleVariants(product))
+  const defaultVariant = $derived(getDefaultVariant(product) ?? eligibleVariants[0]!)
+  let selectedSku = $state(page.url.searchParams.get('variant') ?? '')
+  const variant = $derived(getVariantBySku(eligibleVariants, selectedSku) ?? defaultVariant)
+  const variantPresentation = $derived(getVariantPresentation(variant))
+  const variantLabel = $derived(getVariantLabel(variant))
+  const variantImage = $derived(
+    getVariantImage({
+      fallbackImage: image,
+      productTitle: product.title,
+      variant,
+      variantCount: eligibleVariants.length,
+      variantImages,
+    }),
+  )
+  const priceDisplay = $derived(getVariantPriceDisplay(variant, region.currency_code, locale))
+  const cartItem = $derived(cart?.items?.find(({ variant_id }) => variant_id === variant.id))
+  const selectorOptions = $derived(
+    eligibleVariants.map((eligibleVariant) => ({
+      label: getVariantLabel(eligibleVariant).replace(' — ', ' · '),
+      price: getVariantPriceDisplay(eligibleVariant, region.currency_code, locale)?.current ?? '',
+      value: eligibleVariant.sku!,
+    })),
+  )
   const reviews = $derived(data.reviews)
   const visibleReviews = $derived(data.reviews.reviews)
   const averageRating = $derived(Math.round(reviews.average_rating * 10) / 10)
@@ -86,10 +115,10 @@
     return null
   }
 
-  function toGaItem(quantity: string): GaListItem {
+  function toGaItem(quantity: string, selectedVariant: ProductVariant = variant): GaListItem {
     const handle = typeof product.handle === 'string' ? product.handle : null
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
-    const price = product.variants?.[0]?.calculated_price?.calculated_amount
+    const price = selectedVariant.calculated_price?.calculated_amount
     const categoryHandle = getCategoryHandle()
 
     return {
@@ -100,8 +129,30 @@
       item_category: categoryHandle
         ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
         : GA_MISSING.itemCategory,
+      item_variant: getVariantLabel(selectedVariant),
       quantity,
     }
+  }
+
+  function selectVariant(event: Event & { currentTarget: HTMLInputElement }) {
+    const selectedVariant = getVariantBySku(eligibleVariants, event.currentTarget.value)
+    if (!selectedVariant) return
+
+    const nextUrl = new URL(page.url)
+    nextUrl.searchParams.set('variant', event.currentTarget.value)
+    const productSlug = slug ?? product.handle ?? ''
+    buttonState = 'default'
+    selectedSku = selectedVariant.sku ?? ''
+    replaceState(
+      resolve(
+        `/sortiment/${encodeURIComponent(productSlug)}?${nextUrl.searchParams}${nextUrl.hash}`,
+      ),
+      page.state,
+    )
+    trackViewItem({
+      currency: region.currency_code.toUpperCase(),
+      item: toGaItem('1', selectedVariant),
+    })
   }
 
   function getRatingPercentage(rating: number) {
@@ -176,14 +227,11 @@
     }
   }
 
-  $effect(() => {
-    void slug
-
-    untrack(() => {
-      trackViewItem({
-        currency: region.currency_code.toUpperCase(),
-        item: toGaItem('1'),
-      })
+  afterNavigate(() => {
+    selectedSku = page.url.searchParams.get('variant') ?? defaultVariant.sku ?? ''
+    trackViewItem({
+      currency: region.currency_code.toUpperCase(),
+      item: toGaItem('1'),
     })
   })
 </script>
@@ -191,8 +239,8 @@
 <Seo
   title={product.title}
   description={productDescription}
-  image="{image}/w=800,h=800,fit=cover"
-  imageAlt={product.title}
+  image={variantImage ? `${variantImage.url}/w=800,h=800,fit=cover` : ''}
+  imageAlt={variantImage?.altText ?? `${product.title} – ${variantLabel}`}
 />
 
 <Marquee text="{product.title} //" theme="red"></Marquee>
@@ -225,6 +273,8 @@
     <p class=" font-bold text-xs mb-4">{product.subtitle}</p>
     <h1 class="text-2xl mb-2">{product.title}</h1>
     <p class="font-bold text-xs mb-4">{origin}</p>
+    <p class="mb-2 text-sm font-bold">{variantPresentation.packaging}</p>
+    <p class="mb-4 text-xs">{variantPresentation.size}</p>
     {#if priceDisplay}
       <div class="mb-6">
         <p class="text-base font-bold">
@@ -259,11 +309,24 @@
             >
               {buttonText}
             </button>
-            <QuantitySelector min={1} name="quantity" value={cartItem?.quantity} />
+            {#key variant.id}
+              <QuantitySelector min={1} name="quantity" value={cartItem?.quantity ?? 1} />
+            {/key}
           </div>
         </fieldset>
       </Form>
     </div>
+    {#if eligibleVariants.length > 1}
+      <div class="variant-options mb-6 mt-6">
+        <RadioGroup
+          groupLabel="Vælg format"
+          name="variant"
+          onChange={selectVariant}
+          options={selectorOptions}
+          selected={variant.sku ?? ''}
+        />
+      </div>
+    {/if}
     <a
       class="block text-xs italic
       mb-10
@@ -281,16 +344,26 @@
     class="border-b border-black lg:border-0 py-10 lg:py-20 flex justify-center w-full lg:basis-1/2"
   >
     <div class="aspect-square w-full max-w-[896px] lg:mx-auto">
-      {#key image}
-        <img
-          alt={product.title}
-          class="h-full w-full object-contain"
-          srcset={squareSrcSet(image)}
-          src="{image}/w=400,h=400,fit=cover"
-          sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
-          width="896"
-          height="896"
-        />
+      {#key variant.sku}
+        {#if variantImage}
+          <img
+            alt={variantImage.altText}
+            class="h-full w-full object-contain"
+            srcset={squareSrcSet(variantImage.url)}
+            src="{variantImage.url}/w=400,h=400,fit=cover"
+            sizes="(max-width: 500px) 100vw, (max-width: 1792px) 50vw, 896px"
+            width="896"
+            height="896"
+          />
+        {:else}
+          <div
+            class="flex h-full w-full items-center justify-center border border-black bg-white/40 p-8 text-center text-sm font-bold"
+            role="img"
+            aria-label="{product.title} – {variantLabel}. Billede mangler."
+          >
+            Billede mangler
+          </div>
+        {/if}
       {/key}
     </div>
   </div>
@@ -449,3 +522,32 @@
   <p>Op dit cocktails-game med Vermouth</p>
   <a class="btn" href={resolve('/inspiration')}>DYK NED I VORES MANGE DRINKSOPSKRIFTER</a>
 </section>
+
+<style>
+  .variant-options :global(fieldset > ul > li label) {
+    padding-inline-end: 1rem;
+  }
+
+  .variant-options :global(fieldset > ul > li label > div > div) {
+    gap: 0.75rem;
+  }
+
+  .variant-options :global(fieldset > ul > li label > div > div > p:last-child) {
+    margin-inline-start: auto;
+    text-align: end;
+    white-space: nowrap;
+  }
+
+  @media (min-width: 1024px) {
+    .variant-options :global(fieldset > ul) {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+      border: 0;
+    }
+
+    .variant-options :global(fieldset > ul > li) {
+      border: 1px solid currentColor;
+    }
+  }
+</style>

--- a/src/routes/sortiment/[slug=vermouth]/+page.ts
+++ b/src/routes/sortiment/[slug=vermouth]/+page.ts
@@ -1,6 +1,11 @@
 import type { PageLoad } from './$types'
 import { vermouths } from '$lib/data/products'
-import { error } from '@sveltejs/kit'
+import {
+  getDefaultVariant,
+  getEligibleVariants,
+  getVariantBySku,
+} from '$lib/helpers/product-variants'
+import { error, redirect } from '@sveltejs/kit'
 import { sdk } from '$lib/medusa'
 
 type ProductReview = {
@@ -75,12 +80,25 @@ export const load: PageLoad = async ({ fetch, params, parent, url }) => {
   const { region } = await parent()
   const data = await sdk.store.product.list({
     handle: params.slug,
-    fields: '*categories,*variants.calculated_price',
+    fields: '*categories,*options,*variants,*variants.options,*variants.calculated_price',
     region_id: region.id,
   })
 
   const vermouth = vermouths[vermouthSlug]
   const product = data.products[0]
+  if (!product) error(404, `Vermouth med id: ${params.slug} eksisterer ikke.`)
+
+  const eligibleVariants = getEligibleVariants(product)
+  const defaultVariant = getDefaultVariant(product)
+  if (!defaultVariant?.sku) error(503, 'Produktet kan ikke købes lige nu.')
+
+  const requestedVariant = getVariantBySku(eligibleVariants, url.searchParams.get('variant'))
+  if (!requestedVariant) {
+    const normalizedUrl = new URL(url)
+    normalizedUrl.searchParams.set('variant', defaultVariant.sku)
+    redirect(307, `${normalizedUrl.pathname}${normalizedUrl.search}${normalizedUrl.hash}`)
+  }
+
   const reviews = product?.id
     ? await getProductReviews(product.id, fetch, reviewPagination).catch((reviewsError) => {
         console.error('product reviews fetch failed with error: ', reviewsError)

--- a/src/routes/sortiment/[slug=vermouth]/+page.ts
+++ b/src/routes/sortiment/[slug=vermouth]/+page.ts
@@ -89,8 +89,12 @@ export const load: PageLoad = async ({ fetch, params, parent, url }) => {
   if (!product) error(404, `Vermouth med id: ${params.slug} eksisterer ikke.`)
 
   const eligibleVariants = getEligibleVariants(product)
-  const defaultVariant = getDefaultVariant(product)
-  if (!defaultVariant?.sku) error(503, 'Produktet kan ikke købes lige nu.')
+  let defaultVariant
+  try {
+    defaultVariant = getDefaultVariant(product)
+  } catch {
+    error(503, 'Produktet kan ikke købes lige nu.')
+  }
 
   const requestedVariant = getVariantBySku(eligibleVariants, url.searchParams.get('variant'))
   if (!requestedVariant) {

--- a/tests/ecommerce-flow.spec.ts
+++ b/tests/ecommerce-flow.spec.ts
@@ -29,6 +29,8 @@ test('customer can add and remove a product from the cart', async ({ page }) => 
 
   const productRow = page.locator('li').filter({ hasText: productName }).first()
   await expect(productRow).toBeVisible()
+  await expect(productRow).toContainText('Flaske — 100 cl')
+  await expect(productRow.getByRole('img', { name: 'Forzudo Rojo – Flaske, 100 cl' })).toBeVisible()
   await expect(productRow.locator('input[name="quantity"]')).toHaveValue('1')
 
   const selectedShippingMethod = page

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -223,9 +223,16 @@ test.describe('product detail pages', () => {
     await expect(selector.getByText('Flaske · 75 cl')).toBeVisible()
     await expect(page.locator('input[name="variant_id"]')).toHaveValue('variant_test_sardino_rojo')
 
-    await page.getByRole('radio', { name: /Bag-in-Box · 5 L/ }).check()
+    const bibVariant = page.getByRole('radio', { name: /Bag-in-Box · 5 L/ })
+    await bibVariant.scrollIntoViewIfNeeded()
+    await page.evaluate(() => window.scrollBy(0, -100))
+    const scrollPosition = await page.evaluate(() => window.scrollY)
+    expect(scrollPosition).toBeGreaterThan(0)
+
+    await bibVariant.check()
 
     await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-5l-bag-in-box$/)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollPosition)
     await expect(page.locator('input[name="variant_id"]')).toHaveValue(
       'variant_test_sardino_rojo_box',
     )

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -237,6 +237,13 @@ test.describe('product detail pages', () => {
       'variant_test_sardino_rojo_box',
     )
     await expect(page.getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' })).toBeVisible()
+    const productCopy = page.locator('section.split-content > .copy')
+    await expect(
+      productCopy.getByText('Galicien, Nordvestkysten Spanien / 15%', { exact: true }),
+    ).toBeVisible()
+    await expect(
+      productCopy.locator(':scope > p').filter({ hasText: /^Bag-in-Box · 5 L$/ }),
+    ).toBeVisible()
     await expect(page.locator('main')).toContainText(/DKK\s*800[.,]00/)
 
     await page.getByRole('link', { name: 'KØB ELLER SMAG HER' }).click()
@@ -279,8 +286,7 @@ test.describe('product detail pages', () => {
     await page.goto('/sortiment/sardino-rojo', { waitUntil: 'domcontentloaded' })
 
     await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
-    await expect(page.getByText('Flaske', { exact: true }).first()).toBeVisible()
-    await expect(page.getByText('75 cl', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('Flaske · 75 cl', { exact: true }).first()).toBeVisible()
     await expect(page.getByRole('group', { name: 'Vælg format' })).toHaveCount(0)
   })
 

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -239,10 +239,10 @@ test.describe('product detail pages', () => {
     await expect(page.getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' })).toBeVisible()
     const productCopy = page.locator('section.split-content > .copy')
     await expect(
-      productCopy.getByText('Galicien, Nordvestkysten Spanien / 15%', { exact: true }),
+      productCopy.getByText('Galicien, Nordvestkysten Spanien', { exact: true }),
     ).toBeVisible()
     await expect(
-      productCopy.locator(':scope > p').filter({ hasText: /^Bag-in-Box · 5 L$/ }),
+      productCopy.locator(':scope > p').filter({ hasText: /^Bag-in-Box · 5 L · 15%$/ }),
     ).toBeVisible()
     await expect(page.locator('main')).toContainText(/DKK\s*800[.,]00/)
 
@@ -286,7 +286,7 @@ test.describe('product detail pages', () => {
     await page.goto('/sortiment/sardino-rojo', { waitUntil: 'domcontentloaded' })
 
     await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
-    await expect(page.getByText('Flaske · 75 cl', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('Flaske · 75 cl · 15%', { exact: true }).first()).toBeVisible()
     await expect(page.getByRole('group', { name: 'Vælg format' })).toHaveCount(0)
   })
 

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -241,9 +241,12 @@ test.describe('product detail pages', () => {
     await expect(
       productCopy.getByText('Galicien, Nordvestkysten Spanien', { exact: true }),
     ).toBeVisible()
-    await expect(
-      productCopy.locator(':scope > p').filter({ hasText: /^Bag-in-Box · 5 L · 15%$/ }),
-    ).toBeVisible()
+    const headingAndMetadata = productCopy.locator(':scope > p, :scope > h1')
+    const variantDetails = headingAndMetadata.nth(1)
+    await expect(variantDetails).toHaveText('Bag-in-Box · 5 L · 15%')
+    await expect(variantDetails).toHaveClass(/\btext-sm\b/)
+    await expect(variantDetails).not.toHaveClass(/\bfont-bold\b/)
+    await expect(headingAndMetadata.nth(2)).toHaveText('Sardino Rojo')
     await expect(page.locator('main')).toContainText(/DKK\s*800[.,]00/)
 
     await page.getByRole('link', { name: 'KØB ELLER SMAG HER' }).click()

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -241,12 +241,16 @@ test.describe('product detail pages', () => {
     await expect(
       productCopy.getByText('Galicien, Nordvestkysten Spanien', { exact: true }),
     ).toBeVisible()
-    const headingAndMetadata = productCopy.locator(':scope > p, :scope > h1')
-    const variantDetails = headingAndMetadata.nth(1)
+    const productIdentity = productCopy
+      .locator(':scope > div')
+      .filter({ has: page.getByRole('heading', { name: 'Sardino Rojo' }) })
+    const headingAndMetadata = productIdentity.locator(':scope > p, :scope > h1')
+    const variantDetails = headingAndMetadata.nth(0)
     await expect(variantDetails).toHaveText('Bag-in-Box · 5 L · 15%')
     await expect(variantDetails).toHaveClass(/\btext-sm\b/)
     await expect(variantDetails).not.toHaveClass(/\bfont-bold\b/)
-    await expect(headingAndMetadata.nth(2)).toHaveText('Sardino Rojo')
+    await expect(headingAndMetadata.nth(1)).toHaveText('Sardino Rojo')
+    await expect(headingAndMetadata.nth(2)).toHaveText('Galicien, Nordvestkysten Spanien')
     await expect(page.locator('main')).toContainText(/DKK\s*800[.,]00/)
 
     await page.getByRole('link', { name: 'KØB ELLER SMAG HER' }).click()
@@ -332,7 +336,11 @@ test.describe('product detail pages', () => {
 
     await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
     await expect(page.locator('#product-review-list > li')).toHaveCount(2)
-    await expect(page.getByText('4 anmeldelser').first()).toBeVisible()
+    await expect(page.getByRole('link', { name: '4 anmeldelser' })).toHaveAttribute(
+      'href',
+      '#product-reviews',
+    )
+    await expect(page.getByRole('link', { name: 'Læs 4 anmeldelser' })).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'VIS FLERE (2)' })).toBeVisible()
     expect(reviewRequests[0]).toEqual({ limit: '2', offset: '0' })
 

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -215,6 +215,10 @@ test.describe('product detail pages', () => {
     })
 
     await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
+    await expect(page.locator('link[rel="canonical"]').first()).toHaveAttribute(
+      'href',
+      'https://www.vermouth.nu/sortiment/sardino-rojo',
+    )
     const selector = page.getByRole('group', { name: 'Vælg format' })
     await expect(selector.getByText('Flaske · 75 cl')).toBeVisible()
     await expect(page.locator('input[name="variant_id"]')).toHaveValue('variant_test_sardino_rojo')

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -103,6 +103,35 @@ const sardinoRojoProduct = {
   ],
 }
 
+const catalogVariants = {
+  'forzudo-rojo': [
+    { sku: 'forzudo-rojo-100cl-bottle', label: 'Flaske — 100 cl' },
+    { sku: 'forzudo-rojo-3l-bag-in-box', label: 'Bag-in-Box — 3 L' },
+  ],
+  'forzudo-blanco': [
+    { sku: 'forzudo-blanco-100cl-bottle', label: 'Flaske — 100 cl' },
+    { sku: 'forzudo-blanco-3l-bag-in-box', label: 'Bag-in-Box — 3 L' },
+  ],
+  'forzudo-combo': [{ sku: 'forzudo-combo-2x100cl-pack', label: 'Pakke — 2 × 100 cl' }],
+  'sardino-rojo': [
+    { sku: 'sardino-rojo-75cl-bottle', label: 'Flaske — 75 cl' },
+    { sku: 'sardino-rojo-5l-bag-in-box', label: 'Bag-in-Box — 5 L' },
+  ],
+  'sardino-blanco': [
+    { sku: 'sardino-blanco-75cl-bottle', label: 'Flaske — 75 cl' },
+    { sku: 'sardino-blanco-5l-bag-in-box', label: 'Bag-in-Box — 5 L' },
+  ],
+  'sardino-combo': [{ sku: 'sardino-combo-2x75cl-pack', label: 'Pakke — 2 × 75 cl' }],
+  'carmeleta-orange': [{ sku: 'carmeleta-orange-75cl-bottle', label: 'Flaske — 75 cl' }],
+  'carmeleta-blanco': [{ sku: 'carmeleta-blanco-75cl-bottle', label: 'Flaske — 75 cl' }],
+  'carmeleta-rosso': [{ sku: 'carmeleta-rosso-75cl-bottle', label: 'Flaske — 75 cl' }],
+  'carmeleta-combo': [{ sku: 'carmeleta-combo-3x75cl-pack', label: 'Pakke — 3 × 75 cl' }],
+  'mix-red': [{ sku: 'mix-red-3bottles-pack', label: 'Pakke — 3 flasker' }],
+  'mix-white': [{ sku: 'mix-white-3bottles-pack', label: 'Pakke — 3 flasker' }],
+  'mix-trio': [{ sku: 'mix-trio-3bottles-pack', label: 'Pakke — 3 flasker' }],
+  tabira: [{ sku: 'tabira-100cl-bottle', label: 'Flaske — 100 cl' }],
+} satisfies Record<keyof typeof vermouths, Array<{ sku: string; label: string }>>
+
 const pages = [
   { path: '/', text: 'ENDNU IKKE FAN AF VERMOUTH?' },
   { path: '/sortiment', text: 'VIL DU SMAGE FØR DU KØBER?' },
@@ -174,7 +203,9 @@ test.describe('cancellation request flow', () => {
 })
 
 test.describe('product detail pages', () => {
-  for (const [handle, vermouth] of Object.entries(vermouths)) {
+  for (const handle of Object.keys(vermouths) as Array<keyof typeof vermouths>) {
+    const vermouth = vermouths[handle]
+
     test(`/sortiment/${handle} renders product details`, async ({ page }) => {
       await page.goto(`/sortiment/${handle}`, { waitUntil: 'domcontentloaded' })
 
@@ -185,6 +216,32 @@ test.describe('product detail pages', () => {
       await expect(page.locator('main')).toContainText(vermouth.recommendation)
       await expect(page.getByRole('button', { name: 'LÆG I KURV' })).toBeVisible()
     })
+
+    for (const { sku, label } of catalogVariants[handle]) {
+      test(`/sortiment/${handle} adds ${label} to the cart`, async ({ page }) => {
+        await page.goto(`/sortiment/${handle}?variant=${sku}`, {
+          waitUntil: 'domcontentloaded',
+        })
+
+        await expect(page).toHaveURL(
+          new RegExp(`/sortiment/${handle}\\?variant=${encodeURIComponent(sku)}$`),
+        )
+        await expect(page.locator('input[name="variant_id"]')).not.toHaveValue('')
+
+        const cartAction = page.waitForResponse(
+          (response) =>
+            response.request().method() === 'POST' &&
+            response.url().includes('/kurv?/addOrUpdateItemQuantity'),
+        )
+        const cartNavigation = page.waitForURL((url) => url.pathname === '/kurv')
+        await page.getByRole('button', { name: 'LÆG I KURV' }).click()
+        const cartActionResponse = await cartAction
+        expect(cartActionResponse.ok()).toBe(true)
+
+        await cartNavigation
+        await expect(page.locator('li:visible').filter({ hasText: label })).toHaveCount(1)
+      })
+    }
   }
 
   test('normalizes the default SKU and switches all selected-variant context', async ({ page }) => {

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -232,6 +232,16 @@ test.describe('product detail pages', () => {
     await expect(page.getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' })).toBeVisible()
     await expect(page.locator('main')).toContainText(/DKK\s*800[.,]00/)
 
+    await page.getByRole('link', { name: 'KØB ELLER SMAG HER' }).click()
+    await expect(page).toHaveURL(/\/forhandlere$/)
+    await page.goBack()
+
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-5l-bag-in-box$/)
+    await expect(page.locator('input[name="variant_id"]')).toHaveValue(
+      'variant_test_sardino_rojo_box',
+    )
+    await expect(page.getByRole('radio', { name: /Bag-in-Box · 5 L/ })).toBeChecked()
+
     await page.reload({ waitUntil: 'domcontentloaded' })
     await expect(page.getByRole('radio', { name: /Bag-in-Box · 5 L/ })).toBeChecked()
   })

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -80,9 +80,24 @@ const sardinoRojoProduct = {
   variants: [
     {
       id: 'variant_test_sardino_rojo',
+      sku: 'sardino-rojo-75cl-bottle',
+      title: 'Flaske',
+      variant_rank: 0,
+      options: [{ value: '75 cl', option: { title: 'Size' } }],
       calculated_price: {
         calculated_amount: 195,
         original_amount: 195,
+      },
+    },
+    {
+      id: 'variant_test_sardino_rojo_box',
+      sku: 'sardino-rojo-5l-bag-in-box',
+      title: 'Bag-in-Box',
+      variant_rank: 1,
+      options: [{ value: '5 L', option: { title: 'Size' } }],
+      calculated_price: {
+        calculated_amount: 800,
+        original_amount: 800,
       },
     },
   ],
@@ -172,6 +187,82 @@ test.describe('product detail pages', () => {
     })
   }
 
+  test('normalizes the default SKU and switches all selected-variant context', async ({ page }) => {
+    await page.route('**/store/products?handle=sardino-rojo**', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          products: [sardinoRojoProduct],
+        }),
+      })
+    })
+    await page.route('**/api/products/*/reviews**', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reviews: [],
+          average_rating: 0,
+          review_count: 0,
+          count: 0,
+          limit: 2,
+          offset: 0,
+        }),
+      })
+    })
+
+    await page.goto('/sortiment/sardino-rojo?variant=legacy-variant-id', {
+      waitUntil: 'domcontentloaded',
+    })
+
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
+    const selector = page.getByRole('group', { name: 'Vælg format' })
+    await expect(selector.getByText('Flaske · 75 cl')).toBeVisible()
+    await expect(page.locator('input[name="variant_id"]')).toHaveValue('variant_test_sardino_rojo')
+
+    await page.getByRole('radio', { name: /Bag-in-Box · 5 L/ }).check()
+
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-5l-bag-in-box$/)
+    await expect(page.locator('input[name="variant_id"]')).toHaveValue(
+      'variant_test_sardino_rojo_box',
+    )
+    await expect(page.getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' })).toBeVisible()
+    await expect(page.locator('main')).toContainText(/DKK\s*800[.,]00/)
+
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('radio', { name: /Bag-in-Box · 5 L/ })).toBeChecked()
+  })
+
+  test('shows packaging and Size without a selector for one eligible variant', async ({ page }) => {
+    await page.route('**/store/products?handle=sardino-rojo**', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          products: [{ ...sardinoRojoProduct, variants: [sardinoRojoProduct.variants[0]] }],
+        }),
+      })
+    })
+    await page.route('**/api/products/*/reviews**', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reviews: [],
+          average_rating: 0,
+          review_count: 0,
+          count: 0,
+          limit: 2,
+          offset: 0,
+        }),
+      })
+    })
+
+    await page.goto('/sortiment/sardino-rojo', { waitUntil: 'domcontentloaded' })
+
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
+    await expect(page.getByText('Flaske', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('75 cl', { exact: true }).first()).toBeVisible()
+    await expect(page.getByRole('group', { name: 'Vælg format' })).toHaveCount(0)
+  })
+
   test('product reviews load more through URL pagination', async ({ page }) => {
     const reviewRequests: Array<{ limit: string | null; offset: string | null }> = []
 
@@ -207,9 +298,9 @@ test.describe('product detail pages', () => {
     })
 
     await page.goto('/sortiment', { waitUntil: 'networkidle' })
-    await page.locator('a[href="/sortiment/sardino-rojo"]').click()
+    await page.locator('a[href^="/sortiment/sardino-rojo?variant="]').click()
 
-    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo$/)
+    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
     await expect(page.locator('#product-review-list > li')).toHaveCount(2)
     await expect(page.getByText('4 anmeldelser').first()).toBeVisible()
     await expect(page.getByRole('button', { name: 'VIS FLERE (2)' })).toBeVisible()
@@ -217,7 +308,9 @@ test.describe('product detail pages', () => {
 
     await page.getByRole('button', { name: 'VIS FLERE (2)' }).click()
 
-    await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?reviews_limit=4&reviews_offset=0$/)
+    await expect(page).toHaveURL(
+      /\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle&reviews_limit=4&reviews_offset=0$/,
+    )
     await expect(page.locator('#product-review-list > li')).toHaveCount(4)
     await expect(page.getByRole('button', { name: /VIS FLERE/ })).toBeHidden()
     expect(reviewRequests[1]).toEqual({ limit: '4', offset: '0' })


### PR DESCRIPTION
## What changed

- Resolves eligible Medusa variants by calculated regional price, stable SKU, and variant rank; the lowest rank is the explicit default.
- Normalizes missing, legacy, and invalid product URLs to ?variant=<sku> while preserving unrelated query parameters.
- Integrates the accepted classic radio selector into the real product page, with side-by-side desktop choices and stacked mobile choices.
- Updates selected price, SKU-backed static primary image and alt text, cart target, quantity context, social image, and analytics item_variant.
- Makes product cards link to and price their explicit default variant and show packaging plus Size.
- Shows variant presentation and SKU-backed imagery on cart lines while preserving separate variant line items.
- Adds the four approved Forzudo/Sardino Bag-in-Box storefront images and focused unit/browser coverage.

## Why

Implements [VNU-35](https://linear.app/zwergius/issue/VNU-35/implement-the-medusa-backed-product-variant-selector) against the VNU-30 contract and the reconciled development Medusa catalog.

## Acceptance checks

- Defaulting is based on variant rank, not response order.
- Direct, missing, invalid, and reload-safe SKU URLs are covered.
- Switching updates price, image, hidden cart variant ID, quantity component, and analytics context.
- Single-variant products retain visible packaging/Size without rendering a selector.
- Product cards use explicit default SKU URLs and selected default prices/images.
- Missing multi-variant image configuration never falls back to another presentation.
- Desktop (1440 px) and mobile (390 px) visual checks show no horizontal overflow; native radios remain keyboard/assistive-technology accessible.

## Verification

- pnpm test:unit -- --run — 25 passed
- pnpm check — 0 errors (10 pre-existing warnings in unrelated files)
- pnpm lint — passed
- pnpm test:integration — 38 passed, 1 purchase-freeze test skipped by its environment gate
- Svelte autofixer — no issues or suggestions in all changed Svelte files
- git diff --check — passed

## Risk and boundaries

- VNU-7 still owns stock-aware eligibility and fallback.
- VNU-34 still owns migration of storefront image hosting into Medusa.
- Production catalog data is untouched; rollout remains governed by VNU-32.
- The VNU-31 prototype-only alternatives are not carried into this implementation.

## Agent involvement

Implemented and verified with Codex, including unit/browser tests and desktop/mobile visual inspection.