### PR TITLE
VNU-42 Show every variant in product grids

### DIFF
--- a/src/lib/actions/use-viewport-action.ts
+++ b/src/lib/actions/use-viewport-action.ts
@@ -49,6 +49,8 @@ export default function viewport(
 }
 
 interface Attributes {
-  'on:enterViewport': (e: CustomEvent) => void
-  'on:exitViewport': (e: CustomEvent) => void
+  'on:enterViewport'?: (e: CustomEvent) => void
+  'on:exitViewport'?: (e: CustomEvent) => void
+  onenterViewport?: (e: CustomEvent) => void
+  onexitViewport?: (e: CustomEvent) => void
 }

--- a/src/lib/components/product-grid-item.svelte
+++ b/src/lib/components/product-grid-item.svelte
@@ -2,14 +2,14 @@
   import { vermouths, type Handle } from '$lib/data/products'
   import { productSrcSet } from '$lib/helpers/images'
   import {
-    getDefaultVariant,
     getEligibleVariants,
     getVariantImage,
     getVariantImageAltText,
     getVariantLabel,
+    getVariantPriceDisplay,
     getVariantPresentation,
+    type EligibleProductVariant,
   } from '$lib/helpers/product-variants'
-  import { getProductPriceDisplay } from '$lib/helpers/prices'
   import { resolve } from '$app/paths'
   import type { HttpTypes } from '@medusajs/types'
   import type { Attachment } from 'svelte/attachments'
@@ -18,33 +18,32 @@
     currencyCode,
     locale,
     product,
+    variant,
     onSelectItem,
   }: {
     currencyCode: string
     locale: string
     product: HttpTypes.StoreProduct
+    variant: EligibleProductVariant
     onSelectItem?: () => void
   } = $props()
   const { alcoholPercentage, image, origin, variantImages } = $derived(
     vermouths[product.handle as Handle],
   )
-  const defaultVariant = $derived(getDefaultVariant(product))
   const eligibleVariantCount = $derived(getEligibleVariants(product).length)
-  const presentation = $derived(getVariantPresentation(defaultVariant))
-  const imageAltText = $derived(
-    getVariantImageAltText(product.title, getVariantLabel(defaultVariant)),
-  )
+  const presentation = $derived(getVariantPresentation(variant))
+  const imageAltText = $derived(getVariantImageAltText(product.title, getVariantLabel(variant)))
   const configuredImage = $derived(
     getVariantImage({
       fallbackAltText: imageAltText,
-      variantSku: defaultVariant.sku,
+      variantSku: variant.sku,
       variantImages,
     }),
   )
   const storefrontImage = $derived(
     configuredImage ?? (eligibleVariantCount === 1 ? { altText: imageAltText, url: image } : null),
   )
-  const priceDisplay = $derived(getProductPriceDisplay(product, currencyCode, locale))
+  const priceDisplay = $derived(getVariantPriceDisplay(variant, currencyCode, locale))
   let isDiscountBadgeVisible = $state(false)
 
   function handleSelectItem() {
@@ -80,7 +79,7 @@
 <li class="grid-item aspect-[0.677/1] px-11 pb-7 pt-6 md:aspect-square md:py-6">
   <a
     class="flex h-full flex-col items-center"
-    href={resolve(`/sortiment/${product.handle}?variant=${encodeURIComponent(defaultVariant.sku)}`)}
+    href={resolve(`/sortiment/${product.handle}?variant=${encodeURIComponent(variant.sku)}`)}
     onclick={handleSelectItem}
   >
     <h3 class="mb-2 whitespace-nowrap text-lg font-bold text-brand-blue md:mb-4">

--- a/src/lib/helpers/analytics.test.ts
+++ b/src/lib/helpers/analytics.test.ts
@@ -1,0 +1,44 @@
+import { getProductListAnalyticsItem } from '$lib/helpers/analytics'
+import type { EligibleProductVariant } from '$lib/helpers/product-variants'
+import type { HttpTypes } from '@medusajs/types'
+import { describe, expect, it } from 'vitest'
+
+describe('product list analytics', () => {
+  it('attributes a grid item to the displayed variant', () => {
+    const product = {
+      id: 'prod_wine',
+      title: 'Wine',
+    } as HttpTypes.StoreProduct
+    const variant = {
+      id: 'variant_box',
+      sku: 'wine-5l-bag-in-box',
+      title: 'Bag-in-Box',
+      variant_rank: 1,
+      options: [{ value: '5 L', option: { title: 'Size' } }],
+      calculated_price: { calculated_amount: 800 },
+    } as EligibleProductVariant
+
+    expect(
+      getProductListAnalyticsItem({
+        brand: 'Winery',
+        category: 'Red Vermouth',
+        index: 2,
+        listId: 'RED',
+        listName: 'red',
+        product,
+        variant,
+      }),
+    ).toEqual({
+      item_id: 'prod_wine',
+      item_name: 'Wine',
+      price: '800',
+      item_brand: 'Winery',
+      item_category: 'Red Vermouth',
+      item_variant: 'Bag-in-Box — 5 L',
+      item_list_name: 'red',
+      item_list_id: 'RED',
+      index: 2,
+      quantity: '1',
+    })
+  })
+})

--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -1,3 +1,6 @@
+import { getVariantLabel, type EligibleProductVariant } from '$lib/helpers/product-variants'
+import type { HttpTypes } from '@medusajs/types'
+
 type GaListItem = {
   item_id: string
   item_name: string
@@ -39,6 +42,39 @@ const GA_CATEGORY_LABEL_BY_HANDLE = {
   other: 'Orange Vermouth',
   packs: 'Vermouth Bundle',
 } as const
+
+export function getProductListAnalyticsItem({
+  brand,
+  category,
+  index,
+  listId,
+  listName,
+  product,
+  variant,
+}: {
+  brand?: string
+  category?: string
+  index: number
+  listId?: string
+  listName?: string
+  product: HttpTypes.StoreProduct
+  variant: EligibleProductVariant
+}): GaListItem {
+  const price = variant.calculated_price?.calculated_amount
+
+  return {
+    item_id: product.id || GA_MISSING.itemId,
+    item_name: product.title || GA_MISSING.itemName,
+    price: price !== null && price !== undefined ? String(price) : GA_MISSING.price,
+    item_brand: brand || GA_MISSING.itemBrand,
+    item_category: category || GA_MISSING.itemCategory,
+    item_variant: getVariantLabel(variant),
+    item_list_name: listName || GA_MISSING.itemListName,
+    item_list_id: listId || GA_MISSING.itemListId,
+    index,
+    quantity: '1',
+  }
+}
 
 interface WindowWithDataLayer extends Window {
   dataLayer?: Record<string, unknown>[]

--- a/src/lib/helpers/product-variants.test.ts
+++ b/src/lib/helpers/product-variants.test.ts
@@ -7,6 +7,7 @@ import {
   getVariantImageAltText,
   getVariantLabel,
   getVariantPriceDisplay,
+  getVariantGridItems,
 } from '$lib/helpers/product-variants'
 import type { HttpTypes } from '@medusajs/types'
 import { describe, expect, it } from 'vitest'
@@ -60,6 +61,27 @@ describe('product variant selection', () => {
   it('orders eligible variants by rank rather than response order', () => {
     expect(getEligibleVariants(product([box, bottle]))).toEqual([bottle, box])
     expect(getDefaultVariant(product([box, bottle]))).toBe(bottle)
+  })
+
+  it('expands products into rank-ordered grid items without changing product order', () => {
+    const firstProduct = { id: 'first', variants: [box, bottle] } as HttpTypes.StoreProduct
+    const secondVariant = variant({
+      id: 'second-bottle',
+      rank: 0,
+      size: '75 cl',
+      sku: 'second-wine-75cl-bottle',
+      title: 'Flaske',
+    })
+    const secondProduct = {
+      id: 'second',
+      variants: [secondVariant],
+    } as HttpTypes.StoreProduct
+
+    expect(getVariantGridItems([firstProduct, secondProduct])).toEqual([
+      { product: firstProduct, variant: bottle },
+      { product: firstProduct, variant: box },
+      { product: secondProduct, variant: secondVariant },
+    ])
   })
 
   it('rejects a product without an eligible variant', () => {

--- a/src/lib/helpers/product-variants.ts
+++ b/src/lib/helpers/product-variants.ts
@@ -8,6 +8,11 @@ export type EligibleProductVariant = ProductVariant & {
   variant_rank: number
 }
 
+export type VariantGridItem = {
+  product: HttpTypes.StoreProduct
+  variant: EligibleProductVariant
+}
+
 export type VariantPresentation = {
   packaging: string
   size: string
@@ -73,6 +78,12 @@ export function getDefaultVariant(product: HttpTypes.StoreProduct): EligibleProd
   }
 
   return defaultVariant
+}
+
+export function getVariantGridItems(products: HttpTypes.StoreProduct[]): VariantGridItem[] {
+  return products.flatMap((product) =>
+    getEligibleVariants(product).map((variant) => ({ product, variant })),
+  )
 }
 
 export function getVariantBySku(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import type { PageProps } from './$types'
   import viewport from '$lib/actions/use-viewport-action'
   import { squareSrcSet } from '$lib/helpers/images'
+  import { getVariantGridItems } from '$lib/helpers/product-variants'
   import Marquee from '$lib/components/marquee.svelte'
   import ProductGridItem from '$lib/components/product-grid-item.svelte'
   import Seo from '$lib/components/SEO.svelte'
@@ -10,6 +11,7 @@
 
   const { data }: PageProps = $props()
   const { locale, region } = $derived(data)
+  const favoriteVariants = $derived(getVariantGridItems(data.products))
 
   const founders = [
     {
@@ -79,8 +81,8 @@
 <Marquee text="FAVORITTER //" theme="yellow"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each data.products as product (product.id || product.handle)}
-    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
+  {#each favoriteVariants as { product, variant } (variant.sku)}
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} {variant} />
   {/each}
 </ul>
 
@@ -134,8 +136,8 @@
         alt={name}
         class="h-full w-full object-cover opacity-0 transition-opacity"
         use:viewport
-        on:enterViewport={onEnter}
-        on:exitViewport={onExit}
+        onenterViewport={onEnter}
+        onexitViewport={onExit}
         width="400"
         height="400"
         loading="lazy"

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -8,7 +8,7 @@ export const load: PageLoad = async ({ parent }) => {
     limit: 3,
     offset: 0,
     collection_id: dev ? 'pcol_01K9M5TBX8RNQFARPASPH3ASKM' : 'pcol_01KNKSM0FQXSFMJ4VE3KJMF43S',
-    fields: '*variants.calculated_price',
+    fields: '*options,*variants,*variants.options,*variants.calculated_price',
     region_id: region.id,
   })
   return {

--- a/src/routes/sortiment/+page.svelte
+++ b/src/routes/sortiment/+page.svelte
@@ -7,20 +7,20 @@
   import Seo from '$lib/components/SEO.svelte'
   import {
     GA_CATEGORY_LABEL_BY_HANDLE,
-    GA_MISSING,
+    getProductListAnalyticsItem,
     trackSelectItem,
     trackViewItemList,
     type GaListItem,
   } from '$lib/helpers/analytics'
-  import { getDefaultVariant, getVariantLabel } from '$lib/helpers/product-variants'
+  import { getVariantGridItems, type EligibleProductVariant } from '$lib/helpers/product-variants'
   import { resolve } from '$app/paths'
   import type { HttpTypes } from '@medusajs/types'
 
   const { data }: PageProps = $props()
-  const red = $derived.by(() => data.categories.red)
-  const white = $derived.by(() => data.categories.white)
-  const other = $derived.by(() => data.categories.other)
-  const packs = $derived.by(() => data.categories.packs)
+  const red = $derived(getVariantGridItems(data.categories.red))
+  const white = $derived(getVariantGridItems(data.categories.white))
+  const other = $derived(getVariantGridItems(data.categories.other))
+  const packs = $derived(getVariantGridItems(data.categories.packs))
   const { locale, region } = $derived(data)
   const currency = $derived(data.region.currency_code.toUpperCase())
 
@@ -41,42 +41,42 @@
     return null
   }
 
-  function toGaItem(index: number, product: HttpTypes.StoreProduct): GaListItem {
+  function toGaItem(
+    index: number,
+    product: HttpTypes.StoreProduct,
+    variant: EligibleProductVariant,
+  ): GaListItem {
     const categoryHandle = getCategoryHandle(product)
     const handle = typeof product.handle === 'string' ? product.handle : null
     const staticData = handle && handle in vermouths ? vermouths[handle as Handle] : null
-    const variant = getDefaultVariant(product)
-    const price = variant.calculated_price?.calculated_amount
-
-    return {
-      item_id: product.id || GA_MISSING.itemId,
-      item_name: product.title || GA_MISSING.itemName,
-      price: price !== null && price !== undefined ? String(price) : GA_MISSING.price,
-      item_brand: staticData?.brand || GA_MISSING.itemBrand,
-      item_category: categoryHandle
-        ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle]
-        : GA_MISSING.itemCategory,
-      item_variant: getVariantLabel(variant),
-      item_list_name: categoryHandle || GA_MISSING.itemListName,
-      item_list_id: categoryHandle ? categoryHandle.toUpperCase() : GA_MISSING.itemListId,
+    return getProductListAnalyticsItem({
+      brand: staticData?.brand,
+      category: categoryHandle ? GA_CATEGORY_LABEL_BY_HANDLE[categoryHandle] : undefined,
       index,
-      quantity: '1',
-    }
+      listId: categoryHandle?.toUpperCase(),
+      listName: categoryHandle ?? undefined,
+      product,
+      variant,
+    })
   }
 
-  function handleSelectItem(index: number, product: HttpTypes.StoreProduct) {
+  function handleSelectItem(
+    index: number,
+    product: HttpTypes.StoreProduct,
+    variant: EligibleProductVariant,
+  ) {
     trackSelectItem({
       currency,
-      item: toGaItem(index, product),
+      item: toGaItem(index, product, variant),
     })
   }
 
   onMount(() => {
     const items = [
-      ...red.map((product, index) => toGaItem(index + 1, product)),
-      ...white.map((product, index) => toGaItem(index + 1, product)),
-      ...other.map((product, index) => toGaItem(index + 1, product)),
-      ...packs.map((product, index) => toGaItem(index + 1, product)),
+      ...red.map(({ product, variant }, index) => toGaItem(index + 1, product, variant)),
+      ...white.map(({ product, variant }, index) => toGaItem(index + 1, product, variant)),
+      ...other.map(({ product, variant }, index) => toGaItem(index + 1, product, variant)),
+      ...packs.map(({ product, variant }, index) => toGaItem(index + 1, product, variant)),
     ]
 
     trackViewItemList({
@@ -104,12 +104,13 @@
 <Marquee text="ROJO // RØD //" theme="yellow"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each red as product, index (product.id || product.handle)}
+  {#each red as { product, variant }, index (variant.sku)}
     <ProductGridItem
       currencyCode={region.currency_code}
       {locale}
       {product}
-      onSelectItem={() => handleSelectItem(index + 1, product)}
+      {variant}
+      onSelectItem={() => handleSelectItem(index + 1, product, variant)}
     />
   {/each}
 </ul>
@@ -117,12 +118,13 @@
 <Marquee text="BLANCO // HVID //" theme="blue"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each white as product, index (product.id || product.handle)}
+  {#each white as { product, variant }, index (variant.sku)}
     <ProductGridItem
       currencyCode={region.currency_code}
       {locale}
       {product}
-      onSelectItem={() => handleSelectItem(index + 1, product)}
+      {variant}
+      onSelectItem={() => handleSelectItem(index + 1, product, variant)}
     />
   {/each}
 </ul>
@@ -130,12 +132,13 @@
 <Marquee text="ORANGE & ROSÉ //" theme="white"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each other as product, index (product.id || product.handle)}
+  {#each other as { product, variant }, index (variant.sku)}
     <ProductGridItem
       currencyCode={region.currency_code}
       {locale}
       {product}
-      onSelectItem={() => handleSelectItem(index + 1, product)}
+      {variant}
+      onSelectItem={() => handleSelectItem(index + 1, product, variant)}
     />
   {/each}
 </ul>
@@ -143,12 +146,13 @@
 <Marquee text="BUNDLES // PAKKER //" theme="pink"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each packs as product, index (product.id || product.handle)}
+  {#each packs as { product, variant }, index (variant.sku)}
     <ProductGridItem
       currencyCode={region.currency_code}
       {locale}
       {product}
-      onSelectItem={() => handleSelectItem(index + 1, product)}
+      {variant}
+      onSelectItem={() => handleSelectItem(index + 1, product, variant)}
     />
   {/each}
 </ul>

--- a/src/routes/sortiment/[slug=vermouth]/+page.svelte
+++ b/src/routes/sortiment/[slug=vermouth]/+page.svelte
@@ -16,6 +16,7 @@
     getVariantBySku,
     getVariantImage,
     getVariantImageAltText,
+    getVariantGridItems,
     getVariantLabel,
     getVariantPriceDisplay,
     getVariantPresentation,
@@ -36,7 +37,10 @@
 
   const REVIEWS_PAGE_SIZE = 2
 
-  const { red, white, other, packs } = $derived(data.categories)
+  const red = $derived(getVariantGridItems(data.categories.red))
+  const white = $derived(getVariantGridItems(data.categories.white))
+  const other = $derived(getVariantGridItems(data.categories.other))
+  const packs = $derived(getVariantGridItems(data.categories.packs))
   const { cart, locale, product, purchasesPaused, region } = $derived(data)
   const {
     alcoholPercentage,
@@ -496,32 +500,32 @@
 <Marquee text="ROJO // RØD //" theme="yellow"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each red as product (product.id)}
-    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
+  {#each red as { product, variant } (variant.sku)}
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} {variant} />
   {/each}
 </ul>
 
 <Marquee text="BLANCO // HVID //" theme="blue"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each white as product (product.id)}
-    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
+  {#each white as { product, variant } (variant.sku)}
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} {variant} />
   {/each}
 </ul>
 
 <Marquee text="ORANGE & ROSÉ //" theme="white"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each other as product (product.id)}
-    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
+  {#each other as { product, variant } (variant.sku)}
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} {variant} />
   {/each}
 </ul>
 
 <Marquee text="BUNDLES // PAKKER //" theme="pink"></Marquee>
 
 <ul class="grid-layout border-b border-black">
-  {#each packs as product (product.id)}
-    <ProductGridItem currencyCode={region.currency_code} {locale} {product} />
+  {#each packs as { product, variant } (variant.sku)}
+    <ProductGridItem currencyCode={region.currency_code} {locale} {product} {variant} />
   {/each}
 </ul>
 

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -156,6 +156,29 @@ test.describe('site pages', () => {
       await expect(page.locator('footer')).toContainText('info@vermouth.nu')
     })
   }
+
+  test('sortiment renders every eligible variant as its own grid link', async ({ page }) => {
+    await page.goto('/sortiment', { waitUntil: 'domcontentloaded' })
+
+    for (const [handle, variants] of Object.entries(catalogVariants)) {
+      for (const { sku } of variants) {
+        const variantCard = page.locator(
+          `main a[href="/sortiment/${handle}?variant=${encodeURIComponent(sku)}"]`,
+        )
+
+        await expect(variantCard.first()).toBeVisible()
+      }
+    }
+
+    const sardinoBoxCard = page
+      .locator('main a[href="/sortiment/sardino-rojo?variant=sardino-rojo-5l-bag-in-box"]')
+      .first()
+    await expect(sardinoBoxCard.getByText('Bag-in-Box · 5 L · 15%', { exact: true })).toBeVisible()
+    await expect(
+      sardinoBoxCard.getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' }),
+    ).toBeVisible()
+    await expect(sardinoBoxCard).toContainText(/DKK\s*800[.,]00/)
+  })
 })
 
 test.describe('cancellation request flow', () => {
@@ -293,7 +316,11 @@ test.describe('product detail pages', () => {
     await expect(page.locator('input[name="variant_id"]')).toHaveValue(
       'variant_test_sardino_rojo_box',
     )
-    await expect(page.getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' })).toBeVisible()
+    await expect(
+      page
+        .locator('section.split-content')
+        .getByRole('img', { name: 'Sardino Rojo – Bag-in-Box, 5 L' }),
+    ).toBeVisible()
     const productCopy = page.locator('section.split-content > .copy')
     await expect(
       productCopy.getByText('Galicien, Nordvestkysten Spanien', { exact: true }),
@@ -389,7 +416,10 @@ test.describe('product detail pages', () => {
     })
 
     await page.goto('/sortiment', { waitUntil: 'networkidle' })
-    await page.locator('a[href^="/sortiment/sardino-rojo?variant="]').click()
+    await page
+      .locator('a[href="/sortiment/sardino-rojo?variant=sardino-rojo-75cl-bottle"]')
+      .first()
+      .click()
 
     await expect(page).toHaveURL(/\/sortiment\/sardino-rojo\?variant=sardino-rojo-75cl-bottle$/)
     await expect(page.locator('#product-review-list > li')).toHaveCount(2)


### PR DESCRIPTION
## What changed

- expands each eligible Medusa variant into its own product card
- applies this to Sortiment category grids, homepage Favorites, and product-page recommendation grids
- uses the card variant for packaging, Size, price, discount, configured image, and canonical `?variant=<sku>` link
- preserves product order and orders variants by `variant_rank`
- attributes Sortiment list/select analytics to the displayed variant label and price while retaining product-level `item_id`
- requests full variant option data for homepage favorites
- updates integration selectors that previously assumed one card per product

## Why

Customers should be able to discover and navigate directly to every purchasable presentation, including Bag-in-Box, from product grids instead of seeing only the default bottle.

Linear: https://linear.app/zwergius/issue/VNU-42/show-every-purchasable-variant-in-storefront-product-grids

## Acceptance criteria checked

- multi-variant products render one card per eligible variant
- single-variant products still render one card
- every card links to its exact SKU
- Bag-in-Box card presentation, image, and price are variant-specific
- analytics use the displayed variant label and price
- grid ordering remains deterministic

## Verification

- `pnpm check`
- `pnpm lint`
- unit suite: 37 passed
- Playwright suite: 57 passed, 1 purchase-freeze test intentionally skipped unless freeze mode is enabled
- `git diff --check`

## Risk

Low to moderate. Product grids contain more cards, and analytics now emit one list item per displayed variant. Product-detail and cart behavior are unchanged.

## How to test

1. Open `/sortiment`.
2. Confirm Forzudo and Sardino bottle and Bag-in-Box variants appear as separate cards.
3. Confirm each card shows the correct packaging/Size, image, and price.
4. Open a Bag-in-Box card and confirm its SKU is present in the URL and selected on the product page.
5. Check homepage Favorites and the grids below a product page.

## Intentionally not changed

- inventory-aware availability remains owned by VNU-7
- storefront image hosting remains owned by VNU-34
- product-detail selector and cart contracts are unchanged

## Agent involvement

Implemented and verified with Codex.